### PR TITLE
Implementing audit as plugin

### DIFF
--- a/assemblies/plugins/dist/pom.xml
+++ b/assemblies/plugins/dist/pom.xml
@@ -2842,6 +2842,19 @@
         </exclusion>
       </exclusions>
     </dependency>
+    
+    <dependency>
+      <groupId>org.hop</groupId>
+      <artifactId>hop-assemblies-plugins-misc-audit</artifactId>
+      <version>${hop-plugins-misc.version}</version>
+      <type>zip</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <dependency>
       <groupId>org.hop</groupId>

--- a/assemblies/plugins/misc/audit/pom.xml
+++ b/assemblies/plugins/misc/audit/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hop</groupId>
+    <artifactId>hop-assemblies-plugins-misc</artifactId>
+    <version>0.40-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hop-assemblies-plugins-misc-audit</artifactId>
+  <packaging>pom</packaging>
+  <name>Hop Assemblies Plugins Miscellaneous Audit</name>
+  <description></description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.hop</groupId>
+      <artifactId>hop-plugins-misc-audit</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/assemblies/plugins/misc/audit/src/assembly/assembly.xml
+++ b/assemblies/plugins/misc/audit/src/assembly/assembly.xml
@@ -1,0 +1,33 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+
+    <id>hop-assemblies-plugins-misc-audit</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <baseDirectory>misc/audit</baseDirectory>
+    <files>
+        <file>
+            <source>${project.basedir}/src/main/resources/version.xml</source>
+            <outputDirectory>.</outputDirectory>
+            <filtered>true</filtered>
+        </file>
+    </files>
+    <fileSets>
+        <fileSet>
+            <outputDirectory>lib</outputDirectory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <includes>
+                <include>org.hop:hop-plugins-misc-audit:jar</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/assemblies/plugins/misc/audit/src/main/resources/version.xml
+++ b/assemblies/plugins/misc/audit/src/main/resources/version.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<version>${project.version}</version>

--- a/assemblies/plugins/misc/pom.xml
+++ b/assemblies/plugins/misc/pom.xml
@@ -21,6 +21,7 @@
         <module>projects</module>
         <module>testing</module>
         <module>git</module>
+        <module>audit</module>
     </modules>
 
 </project>

--- a/plugins/misc/audit/pom.xml
+++ b/plugins/misc/audit/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>hop-plugins-misc-audit</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Hop Plugins Miscellaneous Audit</name>
+
+  <parent>
+    <groupId>org.hop</groupId>
+    <artifactId>hop-plugins-misc</artifactId>
+    <version>0.40-SNAPSHOT</version>
+  </parent>
+</project>

--- a/plugins/misc/audit/src/main/java/org/apache/hop/audit/plugin/PluginHelpOpenedExtensionPoint.java
+++ b/plugins/misc/audit/src/main/java/org/apache/hop/audit/plugin/PluginHelpOpenedExtensionPoint.java
@@ -1,0 +1,52 @@
+/*! ******************************************************************************
+ *
+ * Hop : The Hop Orchestration Platform
+ *
+ * http://www.project-hop.org
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.apache.hop.audit.plugin;
+
+import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.extension.ExtensionPoint;
+import org.apache.hop.core.extension.IExtensionPoint;
+import org.apache.hop.core.logging.ILogChannel;
+import org.apache.hop.core.plugins.IPlugin;
+
+@ExtensionPoint(
+    id = "AuditPluginHelpOpened",
+    description =
+        "Audit extension which catches when plugin help opened and sends to audit manager.",
+    extensionPointId = "AuditPluginHelpOpened")
+/**
+ * This extension point for capturing the user action of looking for help. By having this data a
+ * plugin developer can take decision on improving help content.
+ */
+public class PluginHelpOpenedExtensionPoint implements IExtensionPoint<IPlugin> {
+
+  /**
+   * Work In Progress: As of now it just print it in the log
+   *
+   * <p>Design Thoughts: It will extract the details from plugin object and send it to a audit
+   * manager which aware where to send the audit information (log, hop server, analytics server).
+   */
+  @Override
+  public void callExtensionPoint(ILogChannel log, IPlugin plugin) throws HopException {
+
+    log.logBasic("Plugin help opened -" + plugin.getName());
+  }
+}

--- a/plugins/misc/audit/src/main/java/org/apache/hop/audit/workflow/WorkflowSavedExtensionPoint.java
+++ b/plugins/misc/audit/src/main/java/org/apache/hop/audit/workflow/WorkflowSavedExtensionPoint.java
@@ -1,0 +1,49 @@
+/*! ******************************************************************************
+ *
+ * Hop : The Hop Orchestration Platform
+ *
+ * http://www.project-hop.org
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.apache.hop.audit.workflow;
+
+import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.extension.ExtensionPoint;
+import org.apache.hop.core.extension.IExtensionPoint;
+import org.apache.hop.core.logging.ILogChannel;
+import org.apache.hop.workflow.WorkflowMeta;
+
+@ExtensionPoint(
+    id = "WorkflowAfterSave",
+    description =
+        "Audit extension which catches when plugin help opened and sends to audit manager.",
+    extensionPointId = "WorkflowAfterSave")
+/** This extension point audits whenever workflow saved */
+public class WorkflowSavedExtensionPoint implements IExtensionPoint<WorkflowMeta> {
+
+  /**
+   * Work In Progress: As of now it just print it in the log
+   *
+   * <p>Design Thoughts: It will extract the details from plugin object and send it to a audit
+   * manager which aware where to send the audit information (log, hop server, analytics server).
+   */
+  @Override
+  public void callExtensionPoint(ILogChannel log, WorkflowMeta meta) throws HopException {
+
+    log.logBasic("Workflow saved - " + meta.getName());
+  }
+}

--- a/plugins/misc/pom.xml
+++ b/plugins/misc/pom.xml
@@ -3,9 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.hop</groupId>
   <artifactId>hop-plugins-misc</artifactId>
-  <version>0.40-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Hop Plugins Miscellaneous</name>
@@ -15,6 +13,85 @@
     <artifactId>hop-plugins</artifactId>
     <version>0.40-SNAPSHOT</version>
   </parent>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.hop</groupId>
+      <artifactId>hop-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${mockito-all.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hop</groupId>
+      <artifactId>hop-ui-swt</artifactId>
+      <version>0.40-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hop</groupId>
+      <artifactId>hop-engine</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hop</groupId>
+      <artifactId>hop-core</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.hop</groupId>
+        <artifactId>hop-core</artifactId>
+        <version>${project.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <!-- test dependencies -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hop</groupId>
+        <artifactId>hop-core</artifactId>
+        <version>${project.version}</version>
+        <classifier>test</classifier>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hop</groupId>
+        <artifactId>hop-engine</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hop</groupId>
+        <artifactId>hop-core</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+  
 
   <profiles>
   <profile>
@@ -29,6 +106,7 @@
       <module>debug</module>
       <module>testing</module>
       <module>git</module>
+      <module>audit</module>
     </modules>
   </profile>
   </profiles>

--- a/ui/src/main/java/org/apache/hop/ui/util/HelpUtils.java
+++ b/ui/src/main/java/org/apache/hop/ui/util/HelpUtils.java
@@ -20,6 +20,9 @@
 
 package org.apache.hop.ui.util;
 
+import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.extension.ExtensionPointHandler;
+import org.apache.hop.core.logging.LogChannel;
 import org.apache.hop.core.plugins.IPlugin;
 import org.apache.hop.core.plugins.TransformPluginType;
 import org.apache.hop.core.util.StringUtil;
@@ -99,6 +102,11 @@ public class HelpUtils {
   public static ShowHelpDialog openHelpDialog( Shell shell, IPlugin plugin ) {
     if ( shell == null || plugin == null ) {
       return null;
+    }
+    try {
+      ExtensionPointHandler.callExtensionPoint(LogChannel.GENERAL, "AuditPluginHelpOpened", plugin);
+    } catch (HopException e) {
+      e.printStackTrace();
     }
     if ( isPluginDocumented( plugin ) ) {
       return openHelpDialog( shell, getHelpDialogTitle( plugin ), plugin.getDocumentationUrl(),


### PR DESCRIPTION
Based on the learning from debug plugin, created audit functionality (similar to org.apache.hop.history.AuditManager) as plugin.
Existing hitory based AuditManager helps to store and retrive things(event, map, state).
In Audit plugin, I hope we observe various auditable actions and send it to AuditManager component.

With this change, for now Audit plugin just logs two events.

- help clicked in any plugin (This is to demonstrate new extension point call)
- workflow saved (This is to demonstrate we can observe any existing extension point call)

```
2020/11/02 06:11:17 - General - Plugin help opened -Special entries
2020/11/02 06:11:32 - Hop - Workflow saved - test-wf
```

Signed-off-by: Mahendran Mookkiah <mahendran.mookkiah@gmail.com>