### PR TITLE
HOP-13 Avoid use of the static modifier for session-unique instances

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/hopgui/dialog/NotePadDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/dialog/NotePadDialog.java
@@ -127,11 +127,11 @@ public class NotePadDialog extends Dialog {
   private Label wlBorderColor;
   private FormData fdlBorderColor;
 
-  private static GuiResource guiresource = GuiResource.getInstance();
+  private GuiResource guiresource = GuiResource.getInstance();
 
-  public static RGB COLOR_RGB_BLACK = guiresource.getColorBlack().getRGB();
-  public static RGB COLOR_RGB_YELLOW = guiresource.getColorYellow().getRGB();
-  public static RGB COLOR_RGB_GRAY = guiresource.getColorGray().getRGB();
+  public RGB COLOR_RGB_BLACK = guiresource.getColorBlack().getRGB();
+  public RGB COLOR_RGB_YELLOW = guiresource.getColorYellow().getRGB();
+  public RGB COLOR_RGB_GRAY = guiresource.getColorGray().getRGB();
 
   private Color fontColor;
   private Color bgColor;


### PR DESCRIPTION
This is another effort for single-sourcing.

See https://github.com/HiromuHota/pentaho-kettle/wiki/Dev%3A-Antipatterns-in-webSpoon#example-use-of-the-static-modifier-for-session-unique-instances