### PR TITLE
Creating Constants for i18n messages

### DIFF
--- a/core/src/main/java/org/apache/hop/i18n/ConstMessages.java
+++ b/core/src/main/java/org/apache/hop/i18n/ConstMessages.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.i18n;
+
+public final class ConstMessages {
+
+  /**
+   * Private constructor to avoid instantiation
+   */
+  private ConstMessages(){
+  }
+
+  public static final String SYSTEM_COMBO_YES = "System.Combo.Yes";
+  public static final String SYSTEM_COMBO_NO = "System.Combo.No";
+}

--- a/core/src/main/java/org/apache/hop/i18n/MessageContants.java
+++ b/core/src/main/java/org/apache/hop/i18n/MessageContants.java
@@ -1,7 +1,0 @@
-package org.apache.hop.i18n;
-
-public interface MessageContants {
-
-  public static final String SYSTEM_COMBO_YES = "System.Combo.Yes";
-  public static final String SYSTEM_COMBO_NO = "System.Combo.No";
-}

--- a/core/src/main/java/org/apache/hop/i18n/MessageContants.java
+++ b/core/src/main/java/org/apache/hop/i18n/MessageContants.java
@@ -1,0 +1,7 @@
+package org.apache.hop.i18n;
+
+public interface MessageContants {
+
+  public static final String SYSTEM_COMBO_YES = "System.Combo.Yes";
+  public static final String SYSTEM_COMBO_NO = "System.Combo.No";
+}

--- a/plugins/transforms/replacestring/src/main/java/org/apache/hop/pipeline/transforms/replacestring/ReplaceStringMeta.java
+++ b/plugins/transforms/replacestring/src/main/java/org/apache/hop/pipeline/transforms/replacestring/ReplaceStringMeta.java
@@ -24,6 +24,7 @@
 package org.apache.hop.pipeline.transforms.replacestring;
 
 import static org.apache.hop.core.ICheckResult.*;
+import static org.apache.hop.i18n.MessageContants.*;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.hop.core.CheckResult;
@@ -103,10 +104,10 @@ public class ReplaceStringMeta extends BaseTransformMeta implements ITransformMe
   protected static final String[] isUnicodeCode = { "no", "yes" };
 
   protected static final String[] caseSensitiveDesc = new String[] {
-    BaseMessages.getString( PKG, "System.Combo.No" ), BaseMessages.getString( PKG, "System.Combo.Yes" ) };
+    BaseMessages.getString( PKG, SYSTEM_COMBO_NO ), BaseMessages.getString( PKG, SYSTEM_COMBO_YES ) };
 
   protected static final String[] isUnicodeDesc = new String[] {
-    BaseMessages.getString( PKG, "System.Combo.No" ), BaseMessages.getString( PKG, "System.Combo.Yes" ) };
+    BaseMessages.getString( PKG, SYSTEM_COMBO_NO ), BaseMessages.getString( PKG, SYSTEM_COMBO_YES ) };
 
   public static final int CASE_SENSITIVE_NO = 0;
 
@@ -117,7 +118,7 @@ public class ReplaceStringMeta extends BaseTransformMeta implements ITransformMe
   public static final int IS_UNICODE_YES = 1;
 
   protected static final String[] wholeWordDesc = new String[] {
-    BaseMessages.getString( PKG, "System.Combo.No" ), BaseMessages.getString( PKG, "System.Combo.Yes" ) };
+    BaseMessages.getString( PKG, SYSTEM_COMBO_NO ), BaseMessages.getString( PKG, SYSTEM_COMBO_YES ) };
 
   protected static final String[] wholeWordCode = { "no", "yes" };
 
@@ -126,7 +127,7 @@ public class ReplaceStringMeta extends BaseTransformMeta implements ITransformMe
   public static final int WHOLE_WORD_YES = 1;
 
   protected static final String[] useRegExDesc = new String[] {
-    BaseMessages.getString( PKG, "System.Combo.No" ), BaseMessages.getString( PKG, "System.Combo.Yes" ) };
+    BaseMessages.getString( PKG, SYSTEM_COMBO_NO ), BaseMessages.getString( PKG, SYSTEM_COMBO_YES ) };
 
   protected static final String[] useRegExCode = { "no", "yes" };
 

--- a/plugins/transforms/replacestring/src/main/java/org/apache/hop/pipeline/transforms/replacestring/ReplaceStringMeta.java
+++ b/plugins/transforms/replacestring/src/main/java/org/apache/hop/pipeline/transforms/replacestring/ReplaceStringMeta.java
@@ -24,7 +24,7 @@
 package org.apache.hop.pipeline.transforms.replacestring;
 
 import static org.apache.hop.core.ICheckResult.*;
-import static org.apache.hop.i18n.MessageContants.*;
+import static org.apache.hop.i18n.ConstMessages.*;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.hop.core.CheckResult;


### PR DESCRIPTION
After the [discussion](https://chat.project-hop.org/hop/pl/edcg4f7s4iypzq9t3cwxgb55zo), Created new constant interface which holds only i18n message related strings. Choosing the package where BaseMessage is present which is being accessed in almost all UI classes.

Not comfortable choosing enum for this case as I don't see option to keep he enum like below and use `.name()` or `.value()` to get the actual string

public static final String SYSTEM_COMBO_YES = "SYSTEM_COMBO_YES";
or
SYSTEM_COMBO_YES("System.Combo.Yes");
or
SYSTEM_COMBO_YES("SYSTEM_COMBO_YES");

After reviewing, we can choose the best option and fix all the [sonarqube issues](https://sonarcloud.io/project/issues?id=hop&issues=AXMjPuw3tNti-jTiWHbA&open=AXMjPuw3tNti-jTiWHbA) reporting the same string and other similar strings.

Signed-off-by: Mahendran Mookkiah <mahendran@apache.org>