### PR TITLE
Use SWT.PUSH instead of SWT.CASCADE for a menuitem w/o a submenu

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/widget/ConditionEditor.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/widget/ConditionEditor.java
@@ -509,7 +509,7 @@ public class ConditionEditor extends Composite {
     switch ( area ) {
       case AREA_NOT:
         mPop = new Menu( widget );
-        MenuItem miNegate = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miNegate = new MenuItem( mPop, SWT.PUSH );
         miNegate.setText( BaseMessages.getString( PKG, "ConditionEditor.NegateCondition" ) );
         miNegate.addSelectionListener( new SelectionAdapter() {
           @Override
@@ -524,7 +524,7 @@ public class ConditionEditor extends Composite {
       case AREA_BACKGROUND:
       case AREA_ICON_ADD:
         mPop = new Menu( widget );
-        MenuItem miAdd = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miAdd = new MenuItem( mPop, SWT.PUSH );
         miAdd.setText( BaseMessages.getString( PKG, "ConditionEditor.AddCondition.Label" ) );
         miAdd.addSelectionListener( new SelectionAdapter() {
           @Override
@@ -536,7 +536,7 @@ public class ConditionEditor extends Composite {
         break;
       case AREA_SUBCONDITION:
         mPop = new Menu( widget );
-        MenuItem miEdit = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miEdit = new MenuItem( mPop, SWT.PUSH );
         miEdit.setText( BaseMessages.getString( PKG, "ConditionEditor.EditCondition.Label" ) );
         miEdit.addSelectionListener( new SelectionAdapter() {
           @Override
@@ -546,7 +546,7 @@ public class ConditionEditor extends Composite {
             widget.redraw();
           }
         } );
-        MenuItem miDel = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miDel = new MenuItem( mPop, SWT.PUSH );
         miDel.setText( BaseMessages.getString( PKG, "ConditionEditor.DeleteCondition.Label" ) );
         miDel.addSelectionListener( new SelectionAdapter() {
           @Override
@@ -559,7 +559,7 @@ public class ConditionEditor extends Composite {
         // Add a sub-condition in the subcondition... (move down)
         final Condition sub = activeCondition.getCondition( cond_nr );
         if ( sub.getLeftValuename() != null ) {
-          miAdd = new MenuItem( mPop, SWT.CASCADE );
+          miAdd = new MenuItem( mPop, SWT.PUSH );
           miAdd.setText( BaseMessages.getString( PKG, "ConditionEditor.AddSubCondition.Label" ) );
           miAdd.addSelectionListener( new SelectionAdapter() {
             @Override
@@ -575,7 +575,7 @@ public class ConditionEditor extends Composite {
         // --------------------------------------------------
         new MenuItem( mPop, SWT.SEPARATOR );
 
-        MenuItem miCopy = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miCopy = new MenuItem( mPop, SWT.PUSH );
         miCopy.setText( BaseMessages.getString( PKG, "ConditionEditor.CopyToClipboard" ) );
         miCopy.addSelectionListener( new SelectionAdapter() {
           @Override
@@ -591,7 +591,7 @@ public class ConditionEditor extends Composite {
 
           }
         } );
-        MenuItem miPasteBef = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miPasteBef = new MenuItem( mPop, SWT.PUSH );
         miPasteBef.setText( BaseMessages.getString( PKG, "ConditionEditor.PasteFromClipboardBeforeCondition" ) );
         miPasteBef.addSelectionListener( new SelectionAdapter() {
           @Override
@@ -618,7 +618,7 @@ public class ConditionEditor extends Composite {
         // --------------------------------------------------
         new MenuItem( mPop, SWT.SEPARATOR );
 
-        MenuItem miPasteAft = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miPasteAft = new MenuItem( mPop, SWT.PUSH );
         miPasteAft.setText( BaseMessages.getString( PKG, "ConditionEditor.PasteFromClipboardAfterCondition" ) );
         miPasteAft.addSelectionListener( new SelectionAdapter() {
           @Override
@@ -644,7 +644,7 @@ public class ConditionEditor extends Composite {
         } );
         // --------------------------------------------------
         new MenuItem( mPop, SWT.SEPARATOR );
-        MenuItem miMoveSub = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miMoveSub = new MenuItem( mPop, SWT.PUSH );
         miMoveSub.setText( BaseMessages.getString( PKG, "ConditionEditor.MoveConditionToSubCondition" ) );
         miMoveSub.addSelectionListener( new SelectionAdapter() {
           @Override
@@ -661,7 +661,7 @@ public class ConditionEditor extends Composite {
             widget.redraw();
           }
         } );
-        MenuItem miMoveParent = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miMoveParent = new MenuItem( mPop, SWT.PUSH );
         miMoveParent.setText( BaseMessages.getString( PKG, "ConditionEditor.MoveConditionToParentCondition" ) );
         if ( getLevel() == 0 ) {
           miMoveParent.setEnabled( false );
@@ -685,7 +685,7 @@ public class ConditionEditor extends Composite {
         } );
         // --------------------------------------------------
         new MenuItem( mPop, SWT.SEPARATOR );
-        MenuItem miMoveDown = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miMoveDown = new MenuItem( mPop, SWT.PUSH );
         miMoveDown.setText( BaseMessages.getString( PKG, "ConditionEditor.MoveConditionDown" ) );
         if ( cond_nr >= activeCondition.nrConditions() - 1 ) {
           miMoveDown.setEnabled( false );
@@ -700,7 +700,7 @@ public class ConditionEditor extends Composite {
             widget.redraw();
           }
         } );
-        MenuItem miMoveUp = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miMoveUp = new MenuItem( mPop, SWT.PUSH );
         miMoveUp.setText( BaseMessages.getString( PKG, "ConditionEditor.MoveConditionUp" ) );
         if ( cond_nr == 0 ) {
           miMoveUp.setEnabled( false );
@@ -721,7 +721,7 @@ public class ConditionEditor extends Composite {
         break;
       case AREA_OPERATOR:
         Menu mPop = new Menu( widget );
-        MenuItem miDown = new MenuItem( mPop, SWT.CASCADE );
+        MenuItem miDown = new MenuItem( mPop, SWT.PUSH );
         miDown.setText( BaseMessages.getString( PKG, "ConditionEditor.MoveDown" ) );
         miDown.addSelectionListener( new SelectionAdapter() {
           @Override


### PR DESCRIPTION
As reported [here](https://bugs.eclipse.org/bugs/show_bug.cgi?id=569046), a menuitem with `SWT.CASCADE` w/o a submenu is NOT clickable on RAP/RWT.
For the purpose of single-sourcing, please change them to `SWT.PUSH`.

This is 0.40-20201024.141657-74:
<img width="742" alt="0 40" src="https://user-images.githubusercontent.com/20668349/99928048-5c7cde00-2cfc-11eb-9ee7-1138487527c2.png">

As can been seen, these menuitems do not have a submenu; hence they can simply be `SWT.PUSH`.

This is the patched one:
<img width="525" alt="Screen Shot 2020-11-22 at 19 59 01" src="https://user-images.githubusercontent.com/20668349/99928273-3a379000-2cfd-11eb-8359-13471d7c6ab2.png">

They look and work same as before.