### PR TITLE
HOP-2446 Workflow and Action code cleanup

### DIFF
--- a/engine/src/main/java/org/apache/hop/core/gui/WorkflowTracker.java
+++ b/engine/src/main/java/org/apache/hop/core/gui/WorkflowTracker.java
@@ -83,7 +83,7 @@ public class WorkflowTracker<T extends WorkflowMeta> {
   }
 
   /**
-   * Creates a jobtracker with a single result (maxChildren children are kept)
+   * Creates a workflow tracker with a single result (maxChildren children are kept)
    *
    * @param workflowMeta the workflow metadata to keep track of
    * @param result  the action result to track.
@@ -94,7 +94,7 @@ public class WorkflowTracker<T extends WorkflowMeta> {
   }
 
   /**
-   * Creates a jobtracker with a single result
+   * Creates a workflow tracker with a single result
    *
    * @param workflowMeta     the workflow metadata to keep track of
    * @param maxChildren The maximum number of children to keep track of
@@ -206,8 +206,7 @@ public class WorkflowTracker<T extends WorkflowMeta> {
         WorkflowTracker tracker = it.previous();
         ActionResult result = tracker.getActionResult();
         if ( result != null ) {
-          if ( actionMeta.getName().equals( result.getActionName() )
-            && actionMeta.getNr() == result.getActionNr() ) {
+          if ( actionMeta.getName().equals( result.getActionName() ) ) {
             return tracker;
           }
         }

--- a/engine/src/main/java/org/apache/hop/workflow/ActionResult.java
+++ b/engine/src/main/java/org/apache/hop/workflow/ActionResult.java
@@ -37,7 +37,6 @@ import java.util.Date;
 public class ActionResult implements Cloneable, Comparator<ActionResult>, Comparable<ActionResult> {
   private Result result;
   private String actionName;
-  private int actionNr;
 
   private String comment;
   private String reason;
@@ -59,7 +58,7 @@ public class ActionResult implements Cloneable, Comparator<ActionResult>, Compar
    * Creates a new action result...
    */
   public ActionResult( Result result, String logChannelId, String comment, String reason, String actionName,
-                       int actionNr, String actionFilename ) {
+                       String actionFilename ) {
     this();
     if ( result != null ) {
       // lightClone doesn't bother cloning all the rows.
@@ -73,23 +72,7 @@ public class ActionResult implements Cloneable, Comparator<ActionResult>, Compar
     this.comment = comment;
     this.reason = reason;
     this.actionName = actionName;
-    this.actionNr = actionNr;
     this.actionFilename = actionFilename;
-  }
-
-  /**
-   * @param result
-   * @param comment
-   * @param reason
-   * @param actionMeta
-   * @deprecated use {@link #ActionResult(Result, String, String, String, String, int, String)}
-   */
-  @Deprecated
-  public ActionResult( Result result, String comment, String reason, ActionMeta actionMeta ) {
-
-    this( result, actionMeta.getAction().getLogChannel().getLogChannelId(), comment, reason, actionMeta != null ? actionMeta
-      .getName() : null, actionMeta != null ? actionMeta.getNr() : 0, actionMeta == null ? null : ( actionMeta.getAction() != null ? actionMeta
-      .getAction().getFilename() : null ) );
   }
 
   @Override
@@ -191,20 +174,6 @@ public class ActionResult implements Cloneable, Comparator<ActionResult>, Compar
     this.actionFilename = actionFilename;
   }
 
-  /**
-   * @return the actionNr
-   */
-  public int getActionNr() {
-    return actionNr;
-  }
-
-  /**
-   * @param actionNr the actionNr to set
-   */
-  public void setActionNr( int actionNr ) {
-    this.actionNr = actionNr;
-  }
-
   @Override
   public int compare( ActionResult one, ActionResult two ) {
     if ( one == null && two != null ) {
@@ -226,11 +195,7 @@ public class ActionResult implements Cloneable, Comparator<ActionResult>, Compar
       return 0;
     }
 
-    int cmp = one.getActionName().compareTo( two.getActionName() );
-    if ( cmp != 0 ) {
-      return cmp;
-    }
-    return Integer.valueOf( one.getActionNr() ).compareTo( Integer.valueOf( two.getActionNr() ) );
+    return one.getActionName().compareTo( two.getActionName() );
   }
 
   @Override

--- a/engine/src/main/java/org/apache/hop/workflow/DelegationAdapter.java
+++ b/engine/src/main/java/org/apache/hop/workflow/DelegationAdapter.java
@@ -17,7 +17,6 @@
 
 package org.apache.hop.workflow;
 
-import org.apache.hop.pipeline.Pipeline;
 import org.apache.hop.pipeline.PipelineExecutionConfiguration;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.engine.IPipelineEngine;
@@ -25,7 +24,7 @@ import org.apache.hop.workflow.engine.IWorkflowEngine;
 
 public class DelegationAdapter implements IDelegationListener {
 
-  @Override public void jobDelegationStarted( IWorkflowEngine<WorkflowMeta> delegatedWorkflow, WorkflowExecutionConfiguration workflowExecutionConfiguration ) {
+  @Override public void workflowDelegationStarted( IWorkflowEngine<WorkflowMeta> delegatedWorkflow, WorkflowExecutionConfiguration workflowExecutionConfiguration ) {
 
   }
 

--- a/engine/src/main/java/org/apache/hop/workflow/IDelegationListener.java
+++ b/engine/src/main/java/org/apache/hop/workflow/IDelegationListener.java
@@ -17,14 +17,13 @@
 
 package org.apache.hop.workflow;
 
-import org.apache.hop.pipeline.Pipeline;
 import org.apache.hop.pipeline.PipelineExecutionConfiguration;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.engine.IPipelineEngine;
 import org.apache.hop.workflow.engine.IWorkflowEngine;
 
 public interface IDelegationListener {
-  void jobDelegationStarted( IWorkflowEngine<WorkflowMeta> delegatedWorkflow, WorkflowExecutionConfiguration workflowExecutionConfiguration );
+  void workflowDelegationStarted( IWorkflowEngine<WorkflowMeta> delegatedWorkflow, WorkflowExecutionConfiguration workflowExecutionConfiguration );
 
   void pipelineDelegationStarted( IPipelineEngine<PipelineMeta> delegatedPipeline, PipelineExecutionConfiguration pipelineExecutionConfiguration );
 }

--- a/engine/src/main/java/org/apache/hop/workflow/Workflow.java
+++ b/engine/src/main/java/org/apache/hop/workflow/Workflow.java
@@ -342,7 +342,7 @@ public abstract class Workflow extends Variables implements IVariables, INamedPa
   private void emergencyWriteJobTracker( Result res ) {
     ActionResult jerFinalResult =
       new ActionResult( res, this.getLogChannelId(), BaseMessages.getString( PKG, "Workflow.Comment.WorkflowFinished" ), null,
-        null, 0, null );
+        null, null );
     WorkflowTracker finalTrack = new WorkflowTracker( this.getWorkflowMeta(), jerFinalResult );
     // workflowTracker is up to date too.
     this.workflowTracker.addWorkflowTracker( finalTrack );
@@ -370,7 +370,7 @@ public abstract class Workflow extends Variables implements IVariables, INamedPa
       // Start the tracking...
       ActionResult jerStart =
         new ActionResult( null, null, BaseMessages.getString( PKG, "Workflow.Comment.WorkflowStarted" ), BaseMessages
-          .getString( PKG, "Workflow.Reason.Started" ), null, 0, null );
+          .getString( PKG, "Workflow.Reason.Started" ), null, null );
       workflowTracker.addWorkflowTracker( new WorkflowTracker( workflowMeta, jerStart ) );
 
       setActive( true );
@@ -415,12 +415,12 @@ public abstract class Workflow extends Variables implements IVariables, INamedPa
         }
         jerEnd =
           new ActionResult( res, jes.getLogChannelId(), BaseMessages.getString( PKG, "Workflow.Comment.WorkflowFinished" ),
-            BaseMessages.getString( PKG, "Workflow.Reason.Finished" ), null, 0, null );
+            BaseMessages.getString( PKG, "Workflow.Reason.Finished" ), null, null );
       } else {
         res = executeFromStart( 0, res, startpoint, null, BaseMessages.getString( PKG, "Workflow.Reason.Started" ) );
         jerEnd =
           new ActionResult( res, startpoint.getAction().getLogChannel().getLogChannelId(), BaseMessages.getString(
-            PKG, "Workflow.Comment.WorkflowFinished" ), BaseMessages.getString( PKG, "Workflow.Reason.Finished" ), null, 0, null );
+            PKG, "Workflow.Comment.WorkflowFinished" ), BaseMessages.getString( PKG, "Workflow.Reason.Finished" ), null, null );
       }
       // Save this result...
       workflowTracker.addWorkflowTracker( new WorkflowTracker( workflowMeta, jerEnd ) );
@@ -555,7 +555,7 @@ public abstract class Workflow extends Variables implements IVariables, INamedPa
 
       // Track the fact that we are going to launch the next action...
       ActionResult jerBefore = new ActionResult( null, null, BaseMessages.getString( PKG, "Workflow.Comment.WorkflowStarted" ), reason,
-        actionMeta.getName(), actionMeta.getNr(), resolve( actionMeta.getAction().getFilename() ) );
+        actionMeta.getName(), resolve( actionMeta.getAction().getFilename() ) );
       workflowTracker.addWorkflowTracker( new WorkflowTracker( workflowMeta, jerBefore ) );
 
       ClassLoader cl = Thread.currentThread().getContextClassLoader();
@@ -617,7 +617,7 @@ public abstract class Workflow extends Variables implements IVariables, INamedPa
       //
       ActionResult jerAfter =
         new ActionResult( newResult, cloneJei.getLogChannel().getLogChannelId(), BaseMessages.getString( PKG,
-          "Workflow.Comment.WorkflowFinished" ), null, actionMeta.getName(), actionMeta.getNr(), resolve(
+          "Workflow.Comment.WorkflowFinished" ), null, actionMeta.getName(), resolve(
           actionMeta.getAction().getFilename() ) );
       workflowTracker.addWorkflowTracker( new WorkflowTracker( workflowMeta, jerAfter ) );
       synchronized ( actionResults ) {

--- a/engine/src/main/java/org/apache/hop/workflow/WorkflowConfiguration.java
+++ b/engine/src/main/java/org/apache/hop/workflow/WorkflowConfiguration.java
@@ -60,7 +60,7 @@ public class WorkflowConfiguration {
     return xml.toString();
   }
 
-  public WorkflowConfiguration( Node configNode, IVariables variables ) throws HopException, HopException, ParseException, IOException {
+  public WorkflowConfiguration( Node configNode, IVariables variables ) throws HopException, ParseException, IOException {
     Node workflowNode = XmlHandler.getSubNode( configNode, WorkflowMeta.XML_TAG );
     Node trecNode = XmlHandler.getSubNode( configNode, WorkflowExecutionConfiguration.XML_TAG );
     workflowExecutionConfiguration = new WorkflowExecutionConfiguration( trecNode );
@@ -69,7 +69,7 @@ public class WorkflowConfiguration {
     workflowMeta = new WorkflowMeta( workflowNode, metadataProvider, variables );
   }
 
-  public static final WorkflowConfiguration fromXml( String xml, IVariables variables ) throws HopException, HopException, ParseException, IOException {
+  public static final WorkflowConfiguration fromXml( String xml, IVariables variables ) throws HopException, ParseException, IOException {
     Document document = XmlHandler.loadXmlString( xml );
     Node configNode = XmlHandler.getSubNode( document, XML_TAG );
     return new WorkflowConfiguration( configNode, variables);

--- a/engine/src/main/java/org/apache/hop/workflow/WorkflowExecutionConfiguration.java
+++ b/engine/src/main/java/org/apache/hop/workflow/WorkflowExecutionConfiguration.java
@@ -53,8 +53,6 @@ public class WorkflowExecutionConfiguration implements IExecutionConfiguration {
 
   private String startActionName;
 
-  private int startActionNr;
-
   private boolean gatheringMetrics;
 
   private boolean expandingRemoteWorkflow;
@@ -233,7 +231,6 @@ public class WorkflowExecutionConfiguration implements IExecutionConfiguration {
     xml.append( "    " ).append( XmlHandler.addTagValue( "clear_log", clearingLog ) );
 
     xml.append( "    " ).append( XmlHandler.addTagValue( "start_copy_name", startActionName ) );
-    xml.append( "    " ).append( XmlHandler.addTagValue( "start_copy_nr", startActionNr ) );
 
     xml.append( "    " ).append( XmlHandler.addTagValue( "gather_metrics", gatheringMetrics ) );
     xml.append( "    " ).append( XmlHandler.addTagValue( "expand_remote_workflow", expandingRemoteWorkflow ) );
@@ -285,7 +282,6 @@ public class WorkflowExecutionConfiguration implements IExecutionConfiguration {
     clearingLog = "Y".equalsIgnoreCase( XmlHandler.getTagValue( configNode, "clear_log" ) );
 
     startActionName = XmlHandler.getTagValue( configNode, "start_copy_name" );
-    startActionNr = Const.toInt( XmlHandler.getTagValue( configNode, "start_copy_nr" ), 0 );
 
     gatheringMetrics = "Y".equalsIgnoreCase( XmlHandler.getTagValue( configNode, "gather_metrics" ) );
 
@@ -356,20 +352,6 @@ public class WorkflowExecutionConfiguration implements IExecutionConfiguration {
    */
   public void setStartActionName( String name ) {
     this.startActionName = name;
-  }
-
-  /**
-   * @return the startCopyNr
-   */
-  public int getStartActionNr() {
-    return startActionNr;
-  }
-
-  /**
-   * @param startCopyNr the startCopyNr to set
-   */
-  public void setStartActionNr( int startCopyNr ) {
-    this.startActionNr = startCopyNr;
   }
 
   /**

--- a/engine/src/main/java/org/apache/hop/workflow/WorkflowHopMeta.java
+++ b/engine/src/main/java/org/apache/hop/workflow/WorkflowHopMeta.java
@@ -106,17 +106,12 @@ public class WorkflowHopMeta extends BaseHopMeta<ActionMeta> implements Cloneabl
     try {
       String fromName = XmlHandler.getTagValue( hopNode, XML_FROM_TAG );
       String toName = XmlHandler.getTagValue( hopNode, XML_TO_TAG );
-      String sFromNr = XmlHandler.getTagValue( hopNode, "from_nr" );
-      String sToNr = XmlHandler.getTagValue( hopNode, "to_nr" );
       String sEnabled = XmlHandler.getTagValue( hopNode, "enabled" );
       String sEvaluation = XmlHandler.getTagValue( hopNode, "evaluation" );
       String sUnconditional = XmlHandler.getTagValue( hopNode, "unconditional" );
 
-      int fromNr = Const.toInt( sFromNr, 0 );
-      int toNr = Const.toInt( sToNr, 0 );
-
-      this.from = workflow.findAction( fromName, fromNr );
-      this.to = workflow.findAction( toName, toNr );
+      this.from = workflow.findAction( fromName );
+      this.to = workflow.findAction( toName );
 
       if ( sEnabled == null ) {
         enabled = true;
@@ -141,8 +136,6 @@ public class WorkflowHopMeta extends BaseHopMeta<ActionMeta> implements Cloneabl
       retval.append( "    " ).append( XmlHandler.openTag( XML_TAG ) ).append( Const.CR );
       retval.append( "      " ).append( XmlHandler.addTagValue( XML_FROM_TAG, this.from.getName() ) );
       retval.append( "      " ).append( XmlHandler.addTagValue( XML_TO_TAG, this.to.getName() ) );
-      retval.append( "      " ).append( XmlHandler.addTagValue( "from_nr", this.from.getNr() ) );
-      retval.append( "      " ).append( XmlHandler.addTagValue( "to_nr", this.to.getNr() ) );
       retval.append( "      " ).append( XmlHandler.addTagValue( "enabled", enabled ) );
       retval.append( "      " ).append( XmlHandler.addTagValue( "evaluation", evaluation ) );
       retval.append( "      " ).append( XmlHandler.addTagValue( "unconditional", unconditional ) );

--- a/engine/src/main/java/org/apache/hop/workflow/WorkflowPainter.java
+++ b/engine/src/main/java/org/apache/hop/workflow/WorkflowPainter.java
@@ -317,7 +317,7 @@ public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
     gc.setAlpha( alpha );
   }
 
-  private ActionResult findActionResult( ActionMeta actionCopy ) {
+  private ActionResult findActionResult( ActionMeta actionMeta ) {
     if ( actionResults == null ) {
       return null;
     }
@@ -326,8 +326,7 @@ public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
     while ( iterator.hasNext() ) {
       ActionResult actionResult = iterator.next();
 
-      if ( actionResult.getActionName().equals( actionCopy.getName() )
-        && actionResult.getActionNr() == actionCopy.getNr() ) {
+      if ( actionResult.getActionName().equals( actionMeta.getName() ) ) {
         return actionResult;
       }
     }

--- a/engine/src/main/java/org/apache/hop/workflow/action/ActionMeta.java
+++ b/engine/src/main/java/org/apache/hop/workflow/action/ActionMeta.java
@@ -60,8 +60,6 @@ public class ActionMeta implements Cloneable, IXml, IGuiPosition, IChanged,
 
   private String suggestion = "";
 
-  private int nr; // Copy nr. 0 is the base copy...
-
   private boolean selected;
 
   private boolean isDeprecated;
@@ -94,7 +92,6 @@ public class ActionMeta implements Cloneable, IXml, IGuiPosition, IChanged,
     retval.append( action.getXml() );
 
     retval.append( "      " ).append( XmlHandler.addTagValue( "parallel", launchingInParallel ) );
-    retval.append( "      " ).append( XmlHandler.addTagValue( "nr", nr ) );
     retval.append( "      " ).append( XmlHandler.addTagValue( "xloc", location.x ) );
     retval.append( "      " ).append( XmlHandler.addTagValue( "yloc", location.y ) );
 
@@ -124,8 +121,7 @@ public class ActionMeta implements Cloneable, IXml, IGuiPosition, IChanged,
         action.setMetadataProvider( metadataProvider ); // inject metadata
         action.loadXml( actionNode, metadataProvider, variables);
 
-        // Handle GUI information: nr & location?
-        setNr( Const.toInt( XmlHandler.getTagValue( actionNode, "nr" ), 0 ) );
+        // Handle GUI information: location?
         setLaunchingInParallel( "Y".equalsIgnoreCase( XmlHandler.getTagValue( actionNode, "parallel" ) ) );
         int x = Const.toInt( XmlHandler.getTagValue( actionNode, "xloc" ), 0 );
         int y = Const.toInt( XmlHandler.getTagValue( actionNode, "yloc" ), 0 );
@@ -154,7 +150,6 @@ public class ActionMeta implements Cloneable, IXml, IGuiPosition, IChanged,
   public void clear() {
     location = new Point(0,0);
     action = null;
-    nr = 0;
     launchingInParallel = false;
     attributesMap = new HashMap<>();
   }
@@ -172,8 +167,6 @@ public class ActionMeta implements Cloneable, IXml, IGuiPosition, IChanged,
 
   public void replaceMeta( ActionMeta actionCopy ) {
     action = (IAction) actionCopy.action.clone();
-    nr = actionCopy.nr; // Copy nr. 0 is the base copy...
-
     selected = actionCopy.selected;
     if ( actionCopy.location != null ) {
       location = new Point( actionCopy.location.x, actionCopy.location.y );
@@ -197,12 +190,12 @@ public class ActionMeta implements Cloneable, IXml, IGuiPosition, IChanged,
       return false;
     }
     ActionMeta je = (ActionMeta) o;
-    return je.action.getName().equalsIgnoreCase( action.getName() ) && je.getNr() == getNr();
+    return je.action.getName().equalsIgnoreCase( action.getName() );
   }
 
   @Override
   public int hashCode() {
-    return action.getName().hashCode() ^ Integer.valueOf( getNr() ).hashCode();
+    return action.getName().hashCode();
   }
 
   public void setAction( IAction je ) {
@@ -266,14 +259,6 @@ public class ActionMeta implements Cloneable, IXml, IGuiPosition, IChanged,
     return action.hasChanged();
   }
 
-  public int getNr() {
-    return nr;
-  }
-
-  public void setNr( int n ) {
-    nr = n;
-  }
-
   public void setLaunchingInParallel( boolean p ) {
     launchingInParallel = p;
   }
@@ -334,9 +319,9 @@ public class ActionMeta implements Cloneable, IXml, IGuiPosition, IChanged,
  
   public String toString() {
     if ( action != null ) {
-      return action.getName() + "." + getNr();
+      return action.getName();
     } else {
-      return "null." + getNr();
+      return "null";
     }
   }
 

--- a/engine/src/main/java/org/apache/hop/www/AddWorkflowServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/AddWorkflowServlet.java
@@ -135,9 +135,8 @@ public class AddWorkflowServlet extends BaseHttpServlet implements IHopServerPlu
 
       // Check if there is a starting point specified.
       String startActionName = workflowExecutionConfiguration.getStartActionName();
-      if ( startActionName != null && !startActionName.isEmpty() ) {
-        int startActionNr = workflowExecutionConfiguration.getStartActionNr();
-        ActionMeta startActionMeta = workflowMeta.findAction( startActionName, startActionNr );
+      if ( startActionName != null && !startActionName.isEmpty() ) {        
+        ActionMeta startActionMeta = workflowMeta.findAction( startActionName );
         workflow.setStartActionMeta( startActionMeta );
       }
 

--- a/engine/src/main/java/org/apache/hop/www/BaseWorkflowServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/BaseWorkflowServlet.java
@@ -76,8 +76,7 @@ public abstract class BaseWorkflowServlet extends BodyHttpServlet {
     // Check if there is a starting point specified.
     String startActionName = workflowExecutionConfiguration.getStartActionName();
     if ( startActionName != null && !startActionName.isEmpty() ) {
-      int startCopyNr = workflowExecutionConfiguration.getStartActionNr();
-      ActionMeta startActionMeta = workflowMeta.findAction( startActionName, startCopyNr );
+      ActionMeta startActionMeta = workflowMeta.findAction( startActionName );
       workflow.setStartActionMeta( startActionMeta );
     }
 

--- a/engine/src/test/java/org/apache/hop/concurrency/WorkflowTrackerConcurrencyTest.java
+++ b/engine/src/test/java/org/apache/hop/concurrency/WorkflowTrackerConcurrencyTest.java
@@ -106,7 +106,7 @@ public class WorkflowTrackerConcurrencyTest {
     for ( int i = 0; i < searchersAmount; i++ ) {
       int lookingFor = updatersAmount * updatersCycles / 2 + i;
       assertTrue( "We are looking for reachable index", lookingFor < updatersAmount * updatersCycles );
-      searchers.add( new Searcher( condition, tracker, mockJobEntryCopy( "workflow-action-" + lookingFor, lookingFor ) ) );
+      searchers.add( new Searcher( condition, tracker, mockActionMeta( "workflow-action-" + lookingFor ) ) );
     }
 
     final AtomicInteger generator = new AtomicInteger( 0 );
@@ -120,10 +120,9 @@ public class WorkflowTrackerConcurrencyTest {
     assertEquals( updatersAmount * updatersCycles, generator.get() );
   }
 
-  static ActionMeta mockJobEntryCopy( String name, int number ) {
+  static ActionMeta mockActionMeta( String name ) {
     ActionMeta copy = mock( ActionMeta.class );
     when( copy.getName() ).thenReturn( name );
-    when( copy.getNr() ).thenReturn( number );
     return copy;
   }
 
@@ -198,7 +197,6 @@ public class WorkflowTrackerConcurrencyTest {
           int id = idGenerator.getAndIncrement();
           ActionResult result = new ActionResult();
           result.setActionName( String.format( resultNameTemplate, id ) );
-          result.setActionNr( id );
           WorkflowTracker child = new WorkflowTracker( mockWorkflowMeta( "child-" + id ), result );
           tracker.addWorkflowTracker( child );
         }

--- a/engine/src/test/java/org/apache/hop/core/gui/WorkflowTrackerTest.java
+++ b/engine/src/test/java/org/apache/hop/core/gui/WorkflowTrackerTest.java
@@ -76,7 +76,7 @@ public class WorkflowTrackerTest {
   public void findJobTracker_EntryNameNotFound() {
     WorkflowTracker workflowTracker = createTracker();
     for ( int i = 0; i < 3; i++ ) {
-      workflowTracker.addWorkflowTracker( createTracker( Integer.toString( i ), 1 ) );
+      workflowTracker.addWorkflowTracker( createTracker( Integer.toString( i ) ) );
     }
 
     ActionMeta copy = createActionMeta( "not match" );
@@ -88,9 +88,9 @@ public class WorkflowTrackerTest {
   public void findJobTracker_EntryNameFound() {
     WorkflowTracker workflowTracker = createTracker();
     WorkflowTracker[] children = new WorkflowTracker[] {
-      createTracker( "0", 1 ),
-      createTracker( "1", 1 ),
-      createTracker( "2", 1 )
+      createTracker( "0" ),
+      createTracker( "1" ),
+      createTracker( "2" )
     };
     for ( WorkflowTracker child : children ) {
       workflowTracker.addWorkflowTracker( child );
@@ -103,16 +103,15 @@ public class WorkflowTrackerTest {
 
 
   private static WorkflowTracker createTracker() {
-    return createTracker( null, -1 );
+    return createTracker( null );
   }
 
-  private static WorkflowTracker createTracker( String actionName, int actionNr ) {
+  private static WorkflowTracker createTracker( String actionName ) {
     WorkflowMeta workflowMeta = mock( WorkflowMeta.class );
     WorkflowTracker workflowTracker = new WorkflowTracker( workflowMeta );
     if ( actionName != null ) {
       ActionResult result = mock( ActionResult.class );
       when( result.getActionName() ).thenReturn( actionName );
-      when( result.getActionNr() ).thenReturn( actionNr );
       workflowTracker.setActionResult( result );
     }
     return workflowTracker;
@@ -123,7 +122,6 @@ public class WorkflowTrackerTest {
     when( action.getName() ).thenReturn( actionName );
 
     ActionMeta actionMeta = new ActionMeta( action );
-    actionMeta.setNr( 1 );
     return actionMeta;
   }
 

--- a/engine/src/test/java/org/apache/hop/workflow/WorkflowMetaTest.java
+++ b/engine/src/test/java/org/apache/hop/workflow/WorkflowMetaTest.java
@@ -131,10 +131,10 @@ public class WorkflowMetaTest {
 
   @Test
   public void shouldUseCoordinatesOfItsTransformsAndNotesWhenCalculatingMinimumPoint() {
-    Point jobEntryPoint = new Point( 500, 500 );
+    Point actionPoint = new Point( 500, 500 );
     Point notePadMetaPoint = new Point( 400, 400 );
-    ActionMeta actionCopy = mock( ActionMeta.class );
-    when( actionCopy.getLocation() ).thenReturn( jobEntryPoint );
+    ActionMeta actionMeta = mock( ActionMeta.class );
+    when( actionMeta.getLocation() ).thenReturn( actionPoint );
     NotePadMeta notePadMeta = mock( NotePadMeta.class );
     when( notePadMeta.getLocation() ).thenReturn( notePadMetaPoint );
 
@@ -144,10 +144,10 @@ public class WorkflowMetaTest {
     assertEquals( 0, point.y );
 
     // when Workflow contains a single transform or note, then workflowMeta should return coordinates of it, subtracting borders
-    workflowMeta.addAction( 0, actionCopy );
+    workflowMeta.addAction( 0, actionMeta );
     Point actualTransformPoint = workflowMeta.getMinimum();
-    assertEquals( jobEntryPoint.x - WorkflowMeta.BORDER_INDENT, actualTransformPoint.x );
-    assertEquals( jobEntryPoint.y - WorkflowMeta.BORDER_INDENT, actualTransformPoint.y );
+    assertEquals( actionPoint.x - WorkflowMeta.BORDER_INDENT, actualTransformPoint.x );
+    assertEquals( actionPoint.y - WorkflowMeta.BORDER_INDENT, actualTransformPoint.y );
 
     // when Workflow contains transform or notes, then workflowMeta should return minimal coordinates of them, subtracting borders
     workflowMeta.addNote( notePadMeta );
@@ -247,9 +247,9 @@ public class WorkflowMetaTest {
   public void testHasLoop_simpleLoop() throws Exception {
     //main->2->3->main
     WorkflowMeta workflowMetaSpy = spy( workflowMeta );
-    ActionMeta actionCopyMain = createJobEntryCopy( "mainTransform" );
-    ActionMeta actionCopy2 = createJobEntryCopy( "transform2" );
-    ActionMeta actionCopy3 = createJobEntryCopy( "transform3" );
+    ActionMeta actionCopyMain = createAction( "mainTransform" );
+    ActionMeta actionCopy2 = createAction( "transform2" );
+    ActionMeta actionCopy3 = createAction( "transform3" );
     when( workflowMetaSpy.findNrPrevActions( actionCopyMain ) ).thenReturn( 1 );
     when( workflowMetaSpy.findPrevAction( actionCopyMain, 0 ) ).thenReturn( actionCopy2 );
     when( workflowMetaSpy.findNrPrevActions( actionCopy2 ) ).thenReturn( 1 );
@@ -263,10 +263,10 @@ public class WorkflowMetaTest {
   public void testHasLoop_loopInPrevTransforms() throws Exception {
     //main->2->3->4->3
     WorkflowMeta workflowMetaSpy = spy( workflowMeta );
-    ActionMeta actionCopyMain = createJobEntryCopy( "mainTransform" );
-    ActionMeta actionCopy2 = createJobEntryCopy( "transform2" );
-    ActionMeta actionCopy3 = createJobEntryCopy( "transform3" );
-    ActionMeta actionCopy4 = createJobEntryCopy( "transform4" );
+    ActionMeta actionCopyMain = createAction( "mainTransform" );
+    ActionMeta actionCopy2 = createAction( "transform2" );
+    ActionMeta actionCopy3 = createAction( "transform3" );
+    ActionMeta actionCopy4 = createAction( "transform4" );
     when( workflowMetaSpy.findNrPrevActions( actionCopyMain ) ).thenReturn( 1 );
     when( workflowMetaSpy.findPrevAction( actionCopyMain, 0 ) ).thenReturn( actionCopy2 );
     when( workflowMetaSpy.findNrPrevActions( actionCopy2 ) ).thenReturn( 1 );
@@ -279,12 +279,11 @@ public class WorkflowMetaTest {
     assertFalse( workflowMetaSpy.hasLoop( actionCopyMain ) );
   }
 
-  private ActionMeta createJobEntryCopy( String name ) {
+  private ActionMeta createAction( String name ) {
     IAction action = mock( IAction.class );
-    ActionMeta actionCopy = new ActionMeta( action );
-    when( actionCopy.getName() ).thenReturn( name );
-    actionCopy.setNr( 0 );
-    return actionCopy;
+    ActionMeta actionMeta = new ActionMeta( action );
+    when( actionMeta.getName() ).thenReturn( name );
+    return actionMeta;
   }
 
   @Test

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
@@ -1397,7 +1397,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
                     () -> {
                       try {
                         workflowRunDelegate.executeWorkflow(
-                            hopGui.getVariables(), workflowMeta, null, 0);
+                            hopGui.getVariables(), workflowMeta, null);
                       } catch (Exception e) {
                         new ErrorDialog(
                             getShell(),
@@ -2954,7 +2954,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
   @GuiKeyboardShortcut(control = true, key = 'z')
   @Override
   public void undo() {
-    workflowUndoDelegate.undoJobAction(this, workflowMeta);
+    workflowUndoDelegate.undoWorkflowAction(this, workflowMeta);
     forceFocus();
   }
 
@@ -2968,7 +2968,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
   @GuiKeyboardShortcut(control = true, shift = true, key = 'z')
   @Override
   public void redo() {
-    workflowUndoDelegate.redoJobAction(this, workflowMeta);
+    workflowUndoDelegate.redoWorkflowAction(this, workflowMeta);
     forceFocus();
   }
 
@@ -3497,9 +3497,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
           //
           if (!Utils.isEmpty(executionConfiguration.getStartActionName())) {
             ActionMeta startActionMeta =
-                runWorkflowMeta.findAction(
-                    executionConfiguration.getStartActionName(),
-                    executionConfiguration.getStartActionNr());
+                runWorkflowMeta.findAction(executionConfiguration.getStartActionName());
             workflow.setStartActionMeta(startActionMeta);
           }
 
@@ -3673,7 +3671,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
     // Is the lastChained action still valid?
     //
     if (lastChained != null
-        && workflowMeta.findAction(lastChained.getName(), lastChained.getNr()) == null) {
+        && workflowMeta.findAction(lastChained.getName()) == null) {
       lastChained = null;
     }
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/context/HopGuiWorkflowNoteContext.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/context/HopGuiWorkflowNoteContext.java
@@ -108,14 +108,14 @@ public class HopGuiWorkflowNoteContext extends BaseGuiContextHandler implements 
    *
    * @return value of pipelineGraph
    */
-  public HopGuiWorkflowGraph getJobGraph() {
+  public HopGuiWorkflowGraph getWorkflowGraph() {
     return workflowGraph;
   }
 
   /**
    * @param workflowGraph The pipelineGraph to set
    */
-  public void setJobGraph( HopGuiWorkflowGraph workflowGraph ) {
+  public void setWorkflowGraph( HopGuiWorkflowGraph workflowGraph ) {
     this.workflowGraph = workflowGraph;
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowActionDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowActionDelegate.java
@@ -77,10 +77,10 @@ public class HopGuiWorkflowActionDelegate {
         //
         String actionName = pluginName;
         int nr = 2;
-        ActionMeta check = workflowMeta.findAction(actionName, 0);
+        ActionMeta check = workflowMeta.findAction(actionName);
         while (check != null) {
           actionName = pluginName + " " + nr++;
-          check = workflowMeta.findAction(actionName, 0);
+          check = workflowMeta.findAction(actionName);
         }
 
         // Generate the appropriate class...
@@ -99,41 +99,39 @@ public class HopGuiWorkflowActionDelegate {
         if (openIt) {
           IActionDialog d = getActionDialog(action, workflowMeta);
           if (d != null && d.open() != null) {
-            ActionMeta jge = new ActionMeta();
-            jge.setAction(action);
+            ActionMeta actionMeta = new ActionMeta();
+            actionMeta.setAction(action);
             if (location != null) {
-              jge.setLocation(location.x, location.y);
+              actionMeta.setLocation(location.x, location.y);
             } else {
-              jge.setLocation(50, 50);
+              actionMeta.setLocation(50, 50);
             }
-            jge.setNr(0);
-            workflowMeta.addAction(jge);
+            workflowMeta.addAction(actionMeta);
 
             // Verify that the name is not already used in the workflow.
             //
-            workflowMeta.renameActionIfNameCollides(jge);
+            workflowMeta.renameActionIfNameCollides(actionMeta);
 
             hopGui.undoDelegate.addUndoNew(
-                workflowMeta, new ActionMeta[] {jge}, new int[] {workflowMeta.indexOfAction(jge)});
+                workflowMeta, new ActionMeta[] {actionMeta}, new int[] {workflowMeta.indexOfAction(actionMeta)});
             workflowGraph.updateGui();
-            return jge;
+            return actionMeta;
           } else {
             return null;
           }
         } else {
-          ActionMeta jge = new ActionMeta();
-          jge.setAction(action);
+          ActionMeta actionMeta = new ActionMeta();
+          actionMeta.setAction(action);
           if (location != null) {
-            jge.setLocation(location.x, location.y);
+            actionMeta.setLocation(location.x, location.y);
           } else {
-            jge.setLocation(50, 50);
-          }
-          jge.setNr(0);
-          workflowMeta.addAction(jge);
+            actionMeta.setLocation(50, 50);
+          }          
+          workflowMeta.addAction(actionMeta);
           hopGui.undoDelegate.addUndoNew(
-              workflowMeta, new ActionMeta[] {jge}, new int[] {workflowMeta.indexOfAction(jge)});
+              workflowMeta, new ActionMeta[] {actionMeta}, new int[] {workflowMeta.indexOfAction(actionMeta)});
           workflowGraph.updateGui();
-          return jge;
+          return actionMeta;
         }
       } else {
         return null;
@@ -323,9 +321,7 @@ public class HopGuiWorkflowActionDelegate {
       return;
     }
 
-    ActionMeta copyOfAction = action.clone();
-    copyOfAction.setNr(workflowMeta.findUnusedNr(copyOfAction.getName()));
-
+    ActionMeta copyOfAction = action.clone();  
     Point p = action.getLocation();
     copyOfAction.setLocation(p.x + 10, p.y + 10);
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowRunDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowRunDelegate.java
@@ -67,7 +67,7 @@ public class HopGuiWorkflowRunDelegate {
     jobMap = new ArrayList<>();
   }
 
-  public void executeWorkflow( IVariables variables, WorkflowMeta workflowMeta, String startActionName, int startActionNr ) throws HopException {
+  public void executeWorkflow( IVariables variables, WorkflowMeta workflowMeta, String startActionName ) throws HopException {
 
     if ( workflowMeta == null ) {
       return;
@@ -82,7 +82,6 @@ public class HopGuiWorkflowRunDelegate {
     executionConfiguration.setVariablesMap( variableMap );
     executionConfiguration.getUsedVariables( workflowMeta, variables );
     executionConfiguration.setStartActionName( startActionName );
-    executionConfiguration.setStartActionNr( startActionNr );
     executionConfiguration.setLogLevel( DefaultLogLevel.getLogLevel() );
 
     WorkflowExecutionConfigurationDialog dialog = newWorkflowExecutionConfigurationDialog( executionConfiguration, workflowMeta );
@@ -176,14 +175,14 @@ public class HopGuiWorkflowRunDelegate {
    *
    * @return value of workflowMap
    */
-  public List<WorkflowMeta> getJobMap() {
+  public List<WorkflowMeta> getWorkflowMap() {
     return jobMap;
   }
 
   /**
    * @param jobMap The workflowMap to set
    */
-  public void setJobMap( List<WorkflowMeta> jobMap ) {
+  public void setWorkflowMap( List<WorkflowMeta> jobMap ) {
     this.jobMap = jobMap;
   }
 }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowUndoDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowUndoDelegate.java
@@ -41,17 +41,17 @@ public class HopGuiWorkflowUndoDelegate {
     this.workflowGraph = workflowGraph;
   }
 
-  public void undoJobAction( IHopFileTypeHandler handler, WorkflowMeta workflowMeta ) {
+  public void undoWorkflowAction( IHopFileTypeHandler handler, WorkflowMeta workflowMeta ) {
     ChangeAction changeAction = workflowMeta.previousUndo();
     if ( changeAction == null ) {
       return;
     }
-    undoJobAction( handler, workflowMeta, changeAction );
+    undoWorkflowAction( handler, workflowMeta, changeAction );
     handler.updateGui();
   }
 
 
-  public void undoJobAction( IHopFileTypeHandler handler, WorkflowMeta workflowMeta, ChangeAction changeAction ) {
+  public void undoWorkflowAction( IHopFileTypeHandler handler, WorkflowMeta workflowMeta, ChangeAction changeAction ) {
     switch ( changeAction.getType() ) {
       // We created a new transform : undo this...
       case NewAction:
@@ -185,21 +185,21 @@ public class HopGuiWorkflowUndoDelegate {
     // OK, now check if we need to do this again...
     if ( workflowMeta.viewNextUndo() != null ) {
       if ( workflowMeta.viewNextUndo().getNextAlso() ) {
-        undoJobAction( handler, workflowMeta );
+        undoWorkflowAction( handler, workflowMeta );
       }
     }
   }
 
-  public void redoJobAction( IHopFileTypeHandler handler, WorkflowMeta workflowMeta ) {
+  public void redoWorkflowAction( IHopFileTypeHandler handler, WorkflowMeta workflowMeta ) {
     ChangeAction changeAction = workflowMeta.nextUndo();
     if ( changeAction == null ) {
       return;
     }
-    redoJobAction( handler, workflowMeta, changeAction );
+    redoWorkflowAction( handler, workflowMeta, changeAction );
     handler.updateGui();
   }
 
-  public void redoJobAction( IHopFileTypeHandler handler, WorkflowMeta workflowMeta, ChangeAction changeAction ) {
+  public void redoWorkflowAction( IHopFileTypeHandler handler, WorkflowMeta workflowMeta, ChangeAction changeAction ) {
     switch ( changeAction.getType() ) {
       case NewAction:
         // re-delete the transform at correct location:
@@ -317,7 +317,7 @@ public class HopGuiWorkflowUndoDelegate {
     // OK, now check if we need to do this again...
     if ( workflowMeta.viewNextUndo() != null ) {
       if ( workflowMeta.viewNextUndo().getNextAlso() ) {
-        redoJobAction( handler, workflowMeta );
+        redoWorkflowAction( handler, workflowMeta );
       }
     }
   }
@@ -327,14 +327,14 @@ public class HopGuiWorkflowUndoDelegate {
    *
    * @return value of workflowGraph
    */
-  public HopGuiWorkflowGraph getJobGraph() {
+  public HopGuiWorkflowGraph getWorkflowGraph() {
     return workflowGraph;
   }
 
   /**
    * @param workflowGraph The workflowGraph to set
    */
-  public void setJobGraph( HopGuiWorkflowGraph workflowGraph ) {
+  public void setWorkflowGraph( HopGuiWorkflowGraph workflowGraph ) {
     this.workflowGraph = workflowGraph;
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/extension/HopGuiWorkflowGraphExtension.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/extension/HopGuiWorkflowGraphExtension.java
@@ -39,22 +39,6 @@ public class HopGuiWorkflowGraphExtension {
   }
 
   /**
-   * Gets workflowGraph
-   *
-   * @return value of workflowGraph
-   */
-  public HopGuiWorkflowGraph getJobGraph() {
-    return workflowGraph;
-  }
-
-  /**
-   * @param workflowGraph The workflowGraph to set
-   */
-  public void setJobGraph( HopGuiWorkflowGraph workflowGraph ) {
-    this.workflowGraph = workflowGraph;
-  }
-
-  /**
    * Gets event
    *
    * @return value of event

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/search/HopGuiWorkflowSearchable.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/search/HopGuiWorkflowSearchable.java
@@ -81,7 +81,7 @@ public class HopGuiWorkflowSearchable implements ISearchable<WorkflowMeta> {
       // Select and open the found action?
       //
       if (searchResult.getComponent()!=null) {
-        ActionMeta action = workflowMeta.findAction( searchResult.getComponent(), 0 );
+        ActionMeta action = workflowMeta.findAction( searchResult.getComponent() );
         if (action!=null) {
           action.setSelected( true );
           workflowGraph.editAction(action);

--- a/ui/src/main/java/org/apache/hop/ui/workflow/dialog/WorkflowExecutionConfigurationDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/workflow/dialog/WorkflowExecutionConfigurationDialog.java
@@ -120,7 +120,7 @@ public class WorkflowExecutionConfigurationDialog extends ConfigurationDialog {
     String[] names = new String[ workflowMeta.getActions().size() ];
     for ( int i = 0; i < names.length; i++ ) {
       ActionMeta actionMeta = workflowMeta.getActions().get( i );
-      names[ i ] = getActionName( actionMeta );
+      names[ i ] = actionMeta.getName();
     }
     wStartAction.setItems( names );
   }
@@ -160,10 +160,6 @@ public class WorkflowExecutionConfigurationDialog extends ConfigurationDialog {
     fdRunConfiguration.top = new FormAttachment( 0, props.getMargin() );
     fdRunConfiguration.left = new FormAttachment( 0, 0 );
     wRunConfiguration.setLayoutData( fdRunConfiguration );
-  }
-
-  private String getActionName( ActionMeta meta ) {
-    return meta.getName() + ( meta.getNr() > 0 ? meta.getNr() : "" );
   }
 
   private void getVariablesData() {
@@ -245,9 +241,9 @@ public class WorkflowExecutionConfigurationDialog extends ConfigurationDialog {
     String startAction = "";
     if ( !Utils.isEmpty( getConfiguration().getStartActionName() ) ) {
       ActionMeta action =
-        ( (WorkflowMeta) abstractMeta ).findAction( getConfiguration().getStartActionName(), getConfiguration().getStartActionNr() );
+        ( (WorkflowMeta) abstractMeta ).findAction( getConfiguration().getStartActionName() );
       if ( action != null ) {
-        startAction = getActionName( action );
+        startAction = action.getName();
       }
     }
     wStartAction.setText( startAction );
@@ -300,16 +296,13 @@ public class WorkflowExecutionConfigurationDialog extends ConfigurationDialog {
       configuration.setLogLevel( LogLevel.values()[ wLogLevel.getSelectionIndex() ] );
 
       String startActionName = null;
-      int startActionNr = 0;
       if ( !Utils.isEmpty( wStartAction.getText() ) ) {
         if ( wStartAction.getSelectionIndex() >= 0 ) {
           ActionMeta action = ( (WorkflowMeta) abstractMeta ).getActions().get( wStartAction.getSelectionIndex() );
           startActionName = action.getName();
-          startActionNr = action.getNr();
         }
       }
       getConfiguration().setStartActionName( startActionName );
-      getConfiguration().setStartActionNr( startActionNr );
 
       // The lower part of the dialog...
       getInfoParameters();


### PR DESCRIPTION
- Remove notion copy number for Action
- ActionResult: remove deprecated constructor
- WorkflowMeta: remove deprecated methods get/set Arguments
- DelegationAdapter: rename method with 'job' word
- HopGuiWorkflowUndoDelegate: rename method with 'job' word
- HopGuiWorkflowNoteContext : rename method with 'job' word
- HopGuiWorkflowGraphExtension: remove method with 'job' word, same
method with workflow exist

