### PR TITLE
HOP-2485 - Docker container references wrong deployment folder

### DIFF
--- a/docker/resources/dev-build-local-image.sh
+++ b/docker/resources/dev-build-local-image.sh
@@ -1,11 +1,28 @@
-#!/bin/zsh
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 
 # USE THIS FOR LOCAL DEV ONLY
-cd ../../..
+cd ../..
 # create new build
-mvn clean install
+mvn -DskipTests=true clean install
 # unzip new build
-unzip assemblies/client/target/hop-client-*.zip
+unzip assemblies/client/target/hop-client-*.zip -d assemblies/client/target
 # build docker image
 LATEST_BUILD_VERSION=`date '+%Y%m%d%H%M%S'`
 docker build . -f docker/Dockerfile -t apache-hop:${LATEST_BUILD_VERSION}

--- a/docker/resources/dev-build-local-image.sh
+++ b/docker/resources/dev-build-local-image.sh
@@ -1,0 +1,11 @@
+#!/bin/zsh
+
+# USE THIS FOR LOCAL DEV ONLY
+cd ../../..
+# create new build
+mvn clean install
+# unzip new build
+unzip assemblies/client/target/hop-client-*.zip
+# build docker image
+LATEST_BUILD_VERSION=`date '+%Y%m%d%H%M%S'`
+docker build . -f docker/Dockerfile -t apache-hop:${LATEST_BUILD_VERSION}

--- a/docker/resources/get-hop.sh
+++ b/docker/resources/get-hop.sh
@@ -17,6 +17,9 @@
 #
 #
 
+### THIS SCRIPT IS NOT USED ANY MORE
+# just left here in case we ever need it again
+
 # Script used to fetch the latest snapshot version of project hop
 
 set -ex

--- a/docker/resources/run.sh
+++ b/docker/resources/run.sh
@@ -44,4 +44,4 @@ trapper() {
     done
 }
 
-trapper /opt/project-hop/load-and-execute.sh $@
+trapper /opt/hop/load-and-execute.sh $@


### PR DESCRIPTION
I didn't do a full man clean install after doing my changes. I just build a docker image locally and spun up a container testing one of my pipelines which worked successfully.