### PR TITLE
HOP-2547 : Update the Beam plugin to version 2.28.0

### DIFF
--- a/assemblies/plugins/engines/beam/pom.xml
+++ b/assemblies/plugins/engines/beam/pom.xml
@@ -51,7 +51,7 @@
   </repositories>
 
   <properties>
-    <apache-beam-version>2.27.0</apache-beam-version>
+    <apache-beam-version>2.28.0</apache-beam-version>
     <spark-version>2.4.7</spark-version>
     <flink-version>1.9.3</flink-version>
     <json-simple.version>1.1.1</json-simple.version>

--- a/plugins/engines/beam/pom.xml
+++ b/plugins/engines/beam/pom.xml
@@ -50,7 +50,7 @@
   </parent>
 
   <properties>
-    <apache-beam-version>2.27.0</apache-beam-version>
+    <apache-beam-version>2.28.0</apache-beam-version>
     <spark-version>2.4.7</spark-version>
     <flink-version>1.9.3</flink-version>
     <json-simple.version>1.1.1</json-simple.version>

--- a/plugins/engines/beam/src/main/samples/metadata/pipeline-run-configuration/DataFlow.json
+++ b/plugins/engines/beam/src/main/samples/metadata/pipeline-run-configuration/DataFlow.json
@@ -14,7 +14,7 @@
       "gcpAppName": "Hop",
       "gcpInitialNumberOfWorkers": "8",
       "gcpStagingLocation": "gs://kettledataflow/binaries/",
-      "fatJar": "/home/matt/parking/hop-0.60-fat.jar",
+      "fatJar": "/home/matt/parking/hop-0.99-fat.jar",
       "streamingHopTransformsFlushInterval": "1000",
       "transformPluginClasses": "",
       "gcpDiskSizeGb": "",


### PR DESCRIPTION
Fairly simple point release update.