### PR TITLE
[HOP-2784] Change connector doc of Doris

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/doris.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/doris.adoc
@@ -31,6 +31,8 @@ Please see the https://doris.apache.org[Apache Doris website] for more informati
 |Version Included | None
 |Hop Dependencies | None
 |Documentation | https://dev.mysql.com/doc/connector-j/8.0/en/[Documentation Link]
-|JDBC Url | jdbc:mysql://hostname:33060/databaseName
+|JDBC Url | jdbc:mysql://hostname:9030/databaseName
 |===
+
+The port of JDBC Url is same as the query port of Frontend in Doris.
 


### PR DESCRIPTION
The port of JDBC url is incorrect [http://hop.apache.org/manual/latest/database/databases/doris.html]
This PR change the port to query port of Frontend in Doris.
The default port is 9030.

Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/HOP-2784?filter=-1) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[HOP-XXX] - Fixes bug in SessionManager`,
       where you replace `HOP-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`. 