### PR TITLE
Various small fixes

### DIFF
--- a/assemblies/plugins/engines/beam/src/assembly/assembly.xml
+++ b/assemblies/plugins/engines/beam/src/assembly/assembly.xml
@@ -92,7 +92,7 @@
         <include>com.google.api.grpc:grpc-google-cloud-bigtable-v2</include>
         <include>com.google.api.grpc:grpc-google-cloud-pubsub-v1</include>
         <include>com.google.api.grpc:grpc-google-common-protos</include>
-        <include>com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta1</include>
+        <include>com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2</include>
         <include>com.google.api.grpc:proto-google-cloud-bigtable-admin-v2</include>
         <include>com.google.api.grpc:proto-google-cloud-bigtable-v2</include>
         <include>com.google.api.grpc:proto-google-cloud-datastore-v1</include>

--- a/plugins/engines/beam/src/main/java/org/apache/hop/beam/engines/dataflow/DataFlowJvmStart.java
+++ b/plugins/engines/beam/src/main/java/org/apache/hop/beam/engines/dataflow/DataFlowJvmStart.java
@@ -23,6 +23,13 @@ import org.apache.beam.sdk.options.PipelineOptions;
 
 import java.security.Security;
 
+/**
+ * This class will be picked up and used at the very start of a DataFlow JVM. As such it allows us
+ * to disable certain security algorithms so that secure connections automatically pick up the right
+ * one. This is an issue for secure Kafka and Neo4j Aura connections (neo4j+s:// protocol)
+ *
+ * <p>TODO make this configurable somehow.
+ */
 @AutoService(value = JvmInitializer.class)
 public class DataFlowJvmStart implements JvmInitializer {
   @Override

--- a/plugins/engines/beam/src/main/java/org/apache/hop/beam/engines/dataflow/DataFlowJvmStart.java
+++ b/plugins/engines/beam/src/main/java/org/apache/hop/beam/engines/dataflow/DataFlowJvmStart.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.beam.engines.dataflow;
+
+import com.google.auto.service.AutoService;
+import org.apache.beam.sdk.harness.JvmInitializer;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+import java.security.Security;
+
+@AutoService(value = JvmInitializer.class)
+public class DataFlowJvmStart implements JvmInitializer {
+  @Override
+  public void onStartup() {
+    Security.setProperty(
+        "jdk.tls.disabledAlgorithms",
+        "SSLv3, RC4, DES, MD5withRSA, DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL");
+  }
+
+  @Override
+  public void beforeProcessing(PipelineOptions options) {}
+}

--- a/plugins/engines/beam/src/main/java/org/apache/hop/beam/pipeline/handler/BeamGenericTransformHandler.java
+++ b/plugins/engines/beam/src/main/java/org/apache/hop/beam/pipeline/handler/BeamGenericTransformHandler.java
@@ -60,6 +60,7 @@ import org.apache.hop.pipeline.transform.errorhandling.IStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class BeamGenericTransformHandler extends BeamBaseTransformHandler
@@ -293,7 +294,13 @@ public class BeamGenericTransformHandler extends BeamBaseTransformHandler
     String value =
         transformMeta.getAttribute(
             BeamConst.STRING_HOP_BEAM, BeamConst.STRING_TRANSFORM_FLAG_BATCH);
-    return value != null && "true".equalsIgnoreCase(value);
+
+    // If the copies string contains "BATCH" we'll batch the records...
+    //
+    String copiesString = transformMeta.getCopiesString();
+
+    return value != null && "true".equalsIgnoreCase(value)
+        || copiesString != null && copiesString.toUpperCase().contains("BATCH");
   }
 
   public static boolean needsSingleThreading(TransformMeta transformMeta) {
@@ -312,7 +319,7 @@ public class BeamGenericTransformHandler extends BeamBaseTransformHandler
     String[] keyWords = new String[] {"BEAM_SINGLE", "SINGLE_BEAM", "BEAM_OUTPUT", "OUTPUT"};
 
     for (String keyWord : keyWords) {
-      if (copiesString.equalsIgnoreCase(keyWord)) {
+      if (copiesString.contains(keyWord)) {
         return true;
       }
     }

--- a/plugins/transforms/javascript/src/main/java/org/apache/hop/pipeline/transforms/javascript/ScriptValuesDialog.java
+++ b/plugins/transforms/javascript/src/main/java/org/apache/hop/pipeline/transforms/javascript/ScriptValuesDialog.java
@@ -70,7 +70,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.*;
 
-public class ScriptValuesMetaDialog extends BaseTransformDialog implements ITransformDialog {
+public class ScriptValuesDialog extends BaseTransformDialog implements ITransformDialog {
   private static final Class<?> PKG = ScriptValuesMeta.class; // For Translator
 
   private static final String[] YES_NO_COMBO =
@@ -100,7 +100,7 @@ public class ScriptValuesMetaDialog extends BaseTransformDialog implements ITran
   private Menu cMenu;
   private Menu tMenu;
 
-  // Suport for Rename Tree
+  // Support for Rename Tree
   private TreeItem[] lastItem;
   private TreeEditor editor;
 
@@ -138,7 +138,7 @@ public class ScriptValuesMetaDialog extends BaseTransformDialog implements ITran
 
   private RowGeneratorMeta genMeta;
 
-  public ScriptValuesMetaDialog(
+  public ScriptValuesDialog(
       Shell parent, IVariables variables, Object in, PipelineMeta pipelineMeta, String sname) {
 
     super(parent, variables, (BaseTransformMeta) in, pipelineMeta, sname);


### PR DESCRIPTION
HOP-3115 : Beam BigQuery Output failing because of missing dependency
HOP-3125 : Allow security property jdk.tls.disabledAlgorithms to be set
HOP-3124 : JavaScript transform: edit text area too small (rename of class)
HOP-3126 : Beam: re-add support for batching