### PR TITLE
[FIX] Subpipeline specified by using variables

### DIFF
--- a/plugins/transforms/kafka/src/main/java/org/apache/hop/pipeline/transforms/kafka/consumer/KafkaConsumerInput.java
+++ b/plugins/transforms/kafka/src/main/java/org/apache/hop/pipeline/transforms/kafka/consumer/KafkaConsumerInput.java
@@ -100,7 +100,7 @@ public class KafkaConsumerInput
       String realFilename = resolve(meta.getFilename());
       PipelineMeta subTransMeta = new PipelineMeta(realFilename, metadataProvider, true, this);
       subTransMeta.setMetadataProvider(metadataProvider);
-      subTransMeta.setFilename(meta.getFilename());
+      subTransMeta.setFilename(realFilename);
       subTransMeta.setPipelineType(PipelineMeta.PipelineType.SingleThreaded);
       logDetailed("Loaded sub-pipeline '" + realFilename + "'");
 


### PR DESCRIPTION
Subpipeline specified by using variables: messages in the log do not display the correct path to the subpipeline because variables are not resolved.
