### PR TITLE
HOP-3182 : Beam BQ output Truncating table is not working

### DIFF
--- a/plugins/engines/beam/src/main/java/org/apache/hop/beam/core/transform/BeamBQOutputTransform.java
+++ b/plugins/engines/beam/src/main/java/org/apache/hop/beam/core/transform/BeamBQOutputTransform.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -150,7 +150,7 @@ public class BeamBQOutputTransform extends PTransform<PCollection<HopRow>, PDone
 
       BigQueryIO.Write.WriteDisposition writeDisposition;
       if (truncateTable) {
-        writeDisposition = BigQueryIO.Write.WriteDisposition.WRITE_APPEND;
+        writeDisposition = BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE;
       } else {
         if (failIfNotEmpty) {
           writeDisposition = BigQueryIO.Write.WriteDisposition.WRITE_EMPTY;


### PR DESCRIPTION
One of the smaller patches but important regardless