### PR TITLE
HOP-3333 : Fat jar zip64 format causes problems with Spring Boot framework

### DIFF
--- a/plugins/engines/beam/src/main/java/org/apache/hop/beam/pipeline/fatjar/FatJarBuilder.java
+++ b/plugins/engines/beam/src/main/java/org/apache/hop/beam/pipeline/fatjar/FatJarBuilder.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,7 @@ import org.jboss.jandex.Indexer;
 
 import java.io.*;
 import java.util.*;
+import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
@@ -71,8 +72,8 @@ public class FatJarBuilder {
 
     try {
       byte[] buffer = new byte[1024];
-      ZipOutputStream zipOutputStream =
-          new ZipOutputStream(new FileOutputStream(realTargetJarFile));
+      JarOutputStream zipOutputStream =
+          new JarOutputStream(new FileOutputStream(realTargetJarFile));
 
       for (String jarFile : jarFiles) {
 


### PR DESCRIPTION
HOP-3333 : Fat jar zip64 format causes problems with Spring Boot framework