### PR TITLE
(DOC) - Trivial fix in user manual, workflow run configuration page

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/workflow/workflow-run-configurations/workflow-run-configurations.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/workflow/workflow-run-configurations/workflow-run-configurations.adoc
@@ -32,7 +32,7 @@ Each run configuration comes with its own set of parameters and configuration op
 When starting a new transformation click **New** next to 'Workflow run configuration'.
 All run configurations have a name, description and an engine type, each engine type has its own set of configuration options.
 
-Once created, run configurations are available from the 'Pipeline run configuration' list and are ready to use.
+Once created, run configurations are available from the 'Workflow run configuration' list and are ready to use.
 
 image:hop-gui/workflow/workflow-run-configuration.png[Workflow Run configuration,65%,align="left"]
 


### PR DESCRIPTION
Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 
Trivial changes like typos do not require a JIRA issue (javadoc, comments...). 
In this case, just format the pull request title like `(DOC) - Add javadoc in SessionManager`.

---
The workflow run configuration page references "Pipeline run configuration" instead of "Workflow ..."