### PR TITLE
HOP-3529, HOP-3533, HOP-3548, HOP-3549, HOP-3552, HOP-3553, HOP-3554

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,14 +29,13 @@ ENV HOP_LOG_LEVEL=Basic
 ENV HOP_FILE_PATH=
 # file path to hop log file, e.g. ~/hop.err.log
 ENV HOP_LOG_PATH=$DEPLOYMENT_PATH/hop.err.log
-# path to hop config directory
-# ENV /files/project= DISABLED for now 
 # path to jdbc drivers
-ENV HOP_SHARED_JDBC_DIRECTORY=
+ENV HOP_SHARED_JDBC_FOLDER=
 # name of the Hop project to use
 ENV HOP_PROJECT_NAME=
 # path to the home of the hop project. should start with `/files`.
 ENV HOP_PROJECT_DIRECTORY=
+ENV HOP_PROJECT_FOLDER=
 # name of the project config file including file extension
 ENV HOP_PROJECT_CONFIG_FILE_NAME=project-config.json
 # environment to use with hop run
@@ -48,6 +47,9 @@ ENV HOP_RUN_CONFIG=
 # parameters that should be passed on to the hop-run command
 # specify as comma separated list, e.g. PARAM_1=aaa,PARAM_2=bbb
 ENV HOP_RUN_PARAMETERS=
+# System properties that should be set
+# specify as comma separated list, e.g. PROP1=xxx,PROP2=yyy
+ENV HOP_SYSTEM_PROPERTIES=
 # any JRE settings you want to pass on
 # The “-XX:+AggressiveHeap” tells the container to use all memory assigned to the container. 
 # this removed the need to calculate the necessary heap Xmx
@@ -55,6 +57,23 @@ ENV HOP_OPTIONS=-XX:+AggressiveHeap
 # Path to custom entrypoint extension script file - optional
 # e.g. to fetch Hop project files from S3 or gitlab
 ENV HOP_CUSTOM_ENTRYPOINT_EXTENSION_SHELL_FILE_PATH=
+# The server user
+ENV HOP_SERVER_USER=cluster
+# The server password
+ENV HOP_SERVER_PASSWORD=cluster
+# The server hostname
+ENV HOP_SERVER_HOSTNAME=0.0.0.0
+ENV HOP_SERVER_PORT=8080
+# Optional metadata folder to be included in the hop server XML
+ENV HOP_SERVER_METADATA_FOLDER=
+# Optional server SSL configuration variables
+ENV HOP_SERVER_KEYSTORE=
+ENV HOP_SERVER_KEYSTORE_PASSWORD=
+ENV HOP_SERVER_KEY_PASSWORD=
+# Memory optimization options for the server
+ENV HOP_SERVER_MAX_LOG_LINES=
+ENV HOP_SERVER_MAX_LOG_TIMEOUT=
+ENV HOP_SERVER_MAX_OBJECT_TIMEOUT=
 
 # Define en_US.
 # ENV LANGUAGE en_US.UTF-8

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,14 +33,14 @@ ENV HOP_LOG_PATH=$DEPLOYMENT_PATH/hop.err.log
 ENV HOP_SHARED_JDBC_FOLDER=
 # name of the Hop project to use
 ENV HOP_PROJECT_NAME=
-# path to the home of the hop project. should start with `/files`.
+# path to the home of the Hop project..
 ENV HOP_PROJECT_DIRECTORY=
 ENV HOP_PROJECT_FOLDER=
 # name of the project config file including file extension
 ENV HOP_PROJECT_CONFIG_FILE_NAME=project-config.json
 # environment to use with hop run
 ENV HOP_ENVIRONMENT_NAME=
-# comma separated list of paths to environment config files (including filename and file extension). paths should start with `/files`.
+# comma separated list of paths to environment config files (including filename and file extension).
 ENV HOP_ENVIRONMENT_CONFIG_FILE_NAME_PATHS=
 # hop run configuration to use
 ENV HOP_RUN_CONFIG=

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -44,5 +44,9 @@ RUN rm -rf webapps/* \
 COPY ./assemblies/web/target/webapp/ "${CATALINA_HOME}"/webapps/ROOT/
 COPY ./assemblies/plugins/dist/target/plugins "${CATALINA_HOME}"/plugins
 
+COPY ./docker/resources/run-web.sh /tmp/
+
 # Fix hop-config.json
 RUN sed -i 's/config\/projects/${HOP_CONFIG_FOLDER}\/projects/g' "${CATALINA_HOME}"/webapps/ROOT/config/hop-config.json
+
+CMD ["/bin/bash", "/tmp/run-web.sh"]

--- a/docker/resources/load-and-execute.sh
+++ b/docker/resources/load-and-execute.sh
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-#
 
 set -Eeuo pipefail
 
@@ -34,7 +33,6 @@ log() {
 write_server_config() {
     HOP_SERVER_USER=${HOP_SERVER_USER:-cluster}
     HOP_SERVER_PASS=${HOP_SERVER_PASS:-cluster}
-    HOP_SERVER_MASTER=${HOP_SERVER_MASTER:-Y}
     HOP_SERVER_HOSTNAME=${HOP_SERVER_HOSTNAME:-0.0.0.0}
 
     HOP_SERVER_XML=/tmp/hop-server.xml
@@ -48,9 +46,53 @@ write_server_config() {
     echo "    <port>${HOP_SERVER_PORT}</port>" >> ${HOP_SERVER_XML}
     echo "    <username>${HOP_SERVER_USER}</username>" >> ${HOP_SERVER_XML}
     echo "    <password>${HOP_SERVER_PASS}</password>" >> ${HOP_SERVER_XML}
-    echo "  </hop-server>" >> ${HOP_SERVER_XML}
-    echo "</hop-server-config>" >> ${HOP_SERVER_XML}
 
+    # If an SSL configuration is needed we need to include it here
+    #
+    if [ ! -z "${HOP_SERVER_KEYSTORE}"]
+    then
+      log "Configuring SSL with key store file: ${HOP_SERVER_KEYSTORE}"
+      echo "    <sslConfig>" >> ${HOP_SERVER_XML}
+      echo "      <keyStore>${HOP_SERVER_KEYSTORE}</keyStore>" >> ${HOP_SERVER_XML}
+      echo "      <keyStorePassword>${HOP_SERVER_KEYSTORE_PASSWORD}</keyStorePassword>" >> ${HOP_SERVER_XML}
+      if [ ! -z "${HOP_SERVER_KEY_PASSWORD}"]
+      then
+        echo "      <keyPassword>${HOP_SERVER_KEY_PASSWORD}</keyPassword>" >> ${HOP_SERVER_XML}
+      fi
+      echo "    </sslConfig>" >> ${HOP_SERVER_XML}
+    fi
+    echo "  </hop-server>" >> ${HOP_SERVER_XML}
+
+    # If the metadata folder is set, include it in the configuration
+    #
+    if [ ! -z "${HOP_SERVER_METADATA_FOLDER}" ]
+    then
+      log "The server metadata is in folder: ${HOP_SERVER_METADATA_FOLDER}"
+      echo "  <metadata_folder>${HOP_SERVER_METADATA_FOLDER}</metadata_folder>" >> ${HOP_SERVER_XML}
+    fi
+    # The time (in minutes) it takes for a log line to be cleaned up in memory.
+    #
+    if [ ! -z "${HOP_SERVER_MAX_LOG_LINES}" ]
+    then
+      log "The maximum amount of log lines kept is: ${HOP_SERVER_MAX_LOG_LINES}"
+      echo "  <max_log_lines>${HOP_SERVER_MAX_LOG_LINES}</max_log_lines>" >> ${HOP_SERVER_XML}
+    fi
+    # The time (in minutes) that log lines are kept in memory by the server
+    #
+    if [ ! -z "${HOP_SERVER_MAX_LOG_TIMEOUT}" ]
+    then
+      log "Log lines timeout (in minutes) is: ${HOP_SERVER_MAX_LOG_TIMEOUT}"
+      echo "  <max_log_timeout_minutes>${HOP_SERVER_MAX_LOG_TIMEOUT}</max_log_timeout_minutes>" >> ${HOP_SERVER_XML}
+    fi
+    # The time (in minutes) it takes for a pipeline or workflow execution to be removed from the server status.
+    #
+    if [ ! -z "${HOP_SERVER_MAX_OBJECT_TIMEOUT}" ]
+    then
+      log "Object timeout (in minutes) is: ${HOP_SERVER_MAX_OBJECT_TIMEOUT}"
+      echo "  <object_timeout_minutes>${HOP_SERVER_MAX_OBJECT_TIMEOUT}</object_timeout_minutes>" >> ${HOP_SERVER_XML}
+    fi
+
+    echo "</hop-server-config>" >> ${HOP_SERVER_XML}
 }
 
 # retrieve files from volume
@@ -59,45 +101,117 @@ write_server_config() {
 # allow customisation
 # e.g. to fetch hop project files from S3 or github
 if test -f "${HOP_CUSTOM_ENTRYPOINT_EXTENSION_SHELL_FILE_PATH}"; then
-  echo "Sourcing custom entry point extension: ${HOP_CUSTOM_ENTRYPOINT_EXTENSION_SHELL_FILE_PATH}"
+  log "Sourcing custom entry point extension: ${HOP_CUSTOM_ENTRYPOINT_EXTENSION_SHELL_FILE_PATH}"
   source ${HOP_CUSTOM_ENTRYPOINT_EXTENSION_SHELL_FILE_PATH}
 fi
 
-if [ -z "${HOP_FILE_PATH}" ]
+# The common execution options for short and long lived containers
+# The default log level is Basic
+#
+HOP_EXEC_OPTIONS="--level=${HOP_LOG_LEVEL}"
+
+# For backward compatibility we'll still understand the HOP_PROJECT_DIRECTORY variable
+#
+if [ -z "${HOP_PROJECT_FOLDER}" ]
 then
+  if [ ! -z "${HOP_PROJECT_DIRECTORY}" ]
+  then
+    log "Using deprecated option ${HOP_PROJECT_DIRECTORY} for option HOP_PROJECT_FOLDER"
+    HOP_PROJECT_FOLDER="${HOP_PROJECT_DIRECTORY}"
+  fi
+fi
 
-    write_server_config
-    log "Starting a hop-server on port "${HOP_SERVER_PORT}
-    ${DEPLOYMENT_PATH}/hop/hop-server.sh /tmp/hop-server.xml
+# If we need to set system properties
+# By default this is not set
+#
+if [ ! -z "${HOP_SYSTEM_PROPERTIES}" ]
+then
+  log "Setting system properties at runtime: ${HOP_SYSTEM_PROPERTIES}"
+  HOP_EXEC_OPTIONS="${HOP_EXEC_OPTIONS} --system-properties=${HOP_SYSTEM_PROPERTIES}"
+fi
 
-else
+# If a project name is defined we assume that we want to create it in the container
+#
+if [ ! -z "${HOP_PROJECT_NAME}" ]
+then
+  # We need the project folder to be set...
+  #
+  if [ -z "${HOP_PROJECT_FOLDER}" ]
+  then
+    log "Error: please set variable HOP_PROJECT_FOLDER to create project ${HOP_PROJECT_NAME}"
+    exit 9;
+  else
+    log "The project folder is set to: ${HOP_PROJECT_FOLDER}"
+  fi
 
-  log "Registering project config with Hop"
-  log "${DEPLOYMENT_PATH}/hop/hop-conf.sh --project=${HOP_PROJECT_NAME} --project-create --project-home='${HOP_PROJECT_DIRECTORY}' --project-config-file='${HOP_PROJECT_CONFIG_FILE_NAME}'"
+  # The project folder should exist
+  #
+  if [ ! -d "${HOP_PROJECT_FOLDER}" ]
+  then
+    log "Error: the folder specified in variable HOP_PROJECT_FOLDER does not exist: ${HOP_PROJECT_FOLDER}"
+    exit 9;
+  else
+    log "The specified project folder exists"
+  fi
+
+  log "Registering project ${HOP_PROJECT_NAME} in the Hop configuration"
+  log "${DEPLOYMENT_PATH}/hop/hop-conf.sh --project=${HOP_PROJECT_NAME} --project-create --project-home='${HOP_PROJECT_FOLDER}' --project-config-file='${HOP_PROJECT_CONFIG_FILE_NAME}'"
 
   ${DEPLOYMENT_PATH}/hop/hop-conf.sh \
   --project=${HOP_PROJECT_NAME} \
   --project-create \
-  --project-home="${HOP_PROJECT_DIRECTORY}" \
+  --project-home="${HOP_PROJECT_FOLDER}" \
   --project-config-file="${HOP_PROJECT_CONFIG_FILE_NAME}"
 
-  log "Registering environment config with Hop"
-  log "${DEPLOYMENT_PATH}/hop/hop-conf.sh --environment-create --environment=${HOP_ENVIRONMENT_NAME} --environment-project=${HOP_PROJECT_NAME} --environment-config-files='${HOP_ENVIRONMENT_CONFIG_FILE_NAME_PATHS}'"
+  HOP_EXEC_OPTIONS="${HOP_EXEC_OPTIONS} --project=${HOP_PROJECT_NAME}"
 
-  ${DEPLOYMENT_PATH}/hop/hop-conf.sh \
-  --environment=${HOP_ENVIRONMENT_NAME} \
-  --environment-create \
-  --environment-project=${HOP_PROJECT_NAME} \
-  --environment-config-files="${HOP_ENVIRONMENT_CONFIG_FILE_NAME_PATHS}"
+  # If we also have a the environment we want to create that as well...
+  #
+  if [ ! -z "${HOP_ENVIRONMENT_NAME}" ]
+  then
+    log "Registering environment config with Hop"
+    log "${DEPLOYMENT_PATH}/hop/hop-conf.sh --environment-create --environment=${HOP_ENVIRONMENT_NAME} --environment-project=${HOP_PROJECT_NAME} --environment-config-files='${HOP_ENVIRONMENT_CONFIG_FILE_NAME_PATHS}'"
+
+    ${DEPLOYMENT_PATH}/hop/hop-conf.sh \
+    --environment=${HOP_ENVIRONMENT_NAME} \
+    --environment-create \
+    --environment-project=${HOP_PROJECT_NAME} \
+    --environment-purpose="Apache Hop docker container" \
+    --environment-config-files="${HOP_ENVIRONMENT_CONFIG_FILE_NAME_PATHS}"
+
+    HOP_EXEC_OPTIONS="${HOP_EXEC_OPTIONS} --environment=${HOP_ENVIRONMENT_NAME}"
+  else
+    log "Not creating an environment in the container"
+  fi
+
+else
+  log "Not creating a project or environment in the container"
+fi
+
+
+if [ -z "${HOP_FILE_PATH}" ]
+then
+    write_server_config
+    log "Starting a hop-server on port "${HOP_SERVER_PORT}
+    ${DEPLOYMENT_PATH}/hop/hop-server.sh \
+      ${HOP_EXEC_OPTIONS} \
+      /tmp/hop-server.xml \
+      2>&1 | tee ${HOP_LOG_PATH}
+
+else
+
+  if [ -z ${HOP_RUN_CONFIG} ]
+  then
+    log "Please specify which run configuration you want to use to execute with variable HOP_RUN_CONFIG"
+    exit 9;
+  fi
 
   log "Running a single hop workflow / pipeline (${HOP_FILE_PATH})"
   ${DEPLOYMENT_PATH}/hop/hop-run.sh \
     --file=${HOP_FILE_PATH} \
-    --project=${HOP_PROJECT_NAME} \
-    --environment=${HOP_ENVIRONMENT_NAME} \
     --runconfig=${HOP_RUN_CONFIG} \
-    --level=${HOP_LOG_LEVEL} \
     --parameters=${HOP_RUN_PARAMETERS} \
+    ${HOP_EXEC_OPTIONS} \
     2>&1 | tee ${HOP_LOG_PATH}
 fi
   

--- a/docker/resources/load-and-execute.sh
+++ b/docker/resources/load-and-execute.sh
@@ -24,6 +24,12 @@ log() {
     echo `date '+%Y/%m/%d %H:%M:%S'`" - ${1}"
 }
 
+exitWithCode() {
+  echo "${1}" > /tmp/exitcode.txt
+  # log "wrote exit code ${1} to /tmp/exitcode.txt"
+  exit ${1}
+}
+
 #   write the hop-server config to a configuration file
 #   to avoid the password of the server being shown in ps 
 #
@@ -96,7 +102,7 @@ write_server_config() {
 }
 
 # retrieve files from volume
-# ... done via Dockerfile via specifying a volume ... 
+# ... done via Dockerfile via specifying a volume ...
 
 # allow customisation
 # e.g. to fetch hop project files from S3 or github
@@ -139,7 +145,7 @@ then
   if [ -z "${HOP_PROJECT_FOLDER}" ]
   then
     log "Error: please set variable HOP_PROJECT_FOLDER to create project ${HOP_PROJECT_NAME}"
-    exit 9;
+    exitWithCode 9;
   else
     log "The project folder is set to: ${HOP_PROJECT_FOLDER}"
   fi
@@ -149,7 +155,7 @@ then
   if [ ! -d "${HOP_PROJECT_FOLDER}" ]
   then
     log "Error: the folder specified in variable HOP_PROJECT_FOLDER does not exist: ${HOP_PROJECT_FOLDER}"
-    exit 9;
+    exitWithCode 9;
   else
     log "The specified project folder exists"
   fi
@@ -198,12 +204,13 @@ then
       /tmp/hop-server.xml \
       2>&1 | tee ${HOP_LOG_PATH}
 
+    exitWithCode $?
 else
 
   if [ -z ${HOP_RUN_CONFIG} ]
   then
     log "Please specify which run configuration you want to use to execute with variable HOP_RUN_CONFIG"
-    exit 9;
+    exitWithCode 9;
   fi
 
   log "Running a single hop workflow / pipeline (${HOP_FILE_PATH})"
@@ -213,5 +220,7 @@ else
     --parameters=${HOP_RUN_PARAMETERS} \
     ${HOP_EXEC_OPTIONS} \
     2>&1 | tee ${HOP_LOG_PATH}
+
+    exitWithCode $?
 fi
   

--- a/docker/resources/run-web.sh
+++ b/docker/resources/run-web.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log() {
+    echo `date '+%Y/%m/%d %H:%M:%S'`" - ${1}"
+}
+
+#
+# Stopping a running hop web container with 'docker stop' is obviously possible.
+# Doing it with CTRL-C is just more convenient.
+# So we'll start the catalina.sh script in the background and wait until
+# we trap SIGINT or SIGTERM. At that point we'll simply stop Tomcat.
+#
+
+catalina.sh run &
+pid="$!"
+log "Running Apache Tomcat / Hop Web with PID ${pid}"
+trap "log 'Stopping Tomcat'; catalina.sh stop" SIGINT SIGTERM
+
+while kill -0 $pid > /dev/null 2>&1; do
+    wait
+done

--- a/docker/resources/run.sh
+++ b/docker/resources/run.sh
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-#
 
 #
 # When stopping the running hop-server container with 'docker stop' it ended up with an timeout
@@ -45,3 +44,6 @@ trapper() {
 }
 
 trapper /opt/hop/load-and-execute.sh $@
+
+EXIT_CODE=`cat /tmp/exitcode.txt`
+exit ${EXIT_CODE}

--- a/docs/hop-tech-manual/modules/ROOT/pages/docker-container.adoc
+++ b/docs/hop-tech-manual/modules/ROOT/pages/docker-container.adoc
@@ -26,17 +26,29 @@ This is the documentation of the official Apache Hop docker container published 
 https://hub.docker.com/r/apache/incubator-hop
 
 It's a **Hop Docker image** supporting both **short-lived** and **long-lived** setups.
+A short-lived setup executes a pipeline or workflow and stops right after.
+A long-lived setup starts a Hop server and waits for work.
+
+== Operating system
+
+The docker container runs a minimal Linux system called https://hub.docker.com/_/alpine[Alpine].
+OpenJDK version 8 is then used to execute Apache Hop.
+The Linux user used to execute in the container is `hop` and the group is `hop` as well.
 
 == Container Folder Structure
 
 |===
-|Directory | Description
+|Folder | Description
 
 |```/opt/hop```
-| location of the hop package
+| The installation location of the hop client package.
 
 |```/files```
-| here you should mount a directory that contains the **hop and project config** as well as the **workflows and pipelines**.
+| This volume has read-write permissions for Linux user `hop`.
+You can use it for example to mount a folder that contains the **hop and project config** as well as the **workflows and pipelines**.
+
+|```/home/hop```
+| The initial working directory location of the docker container.
 
 |===
 
@@ -44,46 +56,70 @@ It's a **Hop Docker image** supporting both **short-lived** and **long-lived** s
 
 You can provide values for the following environment variables:
 
-For **short-lived** containers (execute a workflow or pipeline):
+|===
+|Environment Variable|Default |Description
+
+|```HOP_LOG_LEVEL```
+|```Basic```
+| The log level, one of: `None`, `Error`, `Minimal`, `Basic`, `Detailed`, `Debug`, `Rowlevel`.
+
+|```HOP_LOG_PATH```
+|```/opt/hop/hop.err.log```
+| File path to the Hop log file
+
+|```HOP_PROJECT_NAME```
+|
+| Name of the Hop project to create in the container.
+You also need to specify the ```HOP_PROJECT_FOLDER``` variable.
+If you do not set this variable, no project or environment will be created.
+
+|```HOP_PROJECT_FOLDER```
+
+`HOP_PROJECT_DIRECTORY` (Deprecated)
+|
+| Path to the home of the Hop project.
+
+|```HOP_PROJECT_CONFIG_FILE_NAME```
+|```project-config.json```
+| Name of the project config file.
+
+|```HOP_ENVIRONMENT_NAME```
+|
+| The name of the Hop environment to create in the container.
+If you do not set this variable, no environment will be created.
+
+|```HOP_ENVIRONMENT_CONFIG_FILE_NAME_PATHS```
+|
+| This is a comma separated list of paths to environment config files (including filename and file extension).
+
+|```HOP_OPTIONS```
+|```-Xmx2G```
+| Any JRE options you want to set
+
+|```HOP_SHARED_JDBC_FOLDER```
+|
+| Path to a folder where your JDCB drivers are located
+
+|```HOP_CUSTOM_ENTRYPOINT_EXTENSION_SHELL_FILE_PATH```
+|
+| Optional path to a custom entrypoint extension script file.
+You can use this for example to fetch Hop project files from S3 or gitlab.
+
+|```HOP_SYSTEM_PROPERTIES```
+|
+| The system properties that should be set during execution.
+You can specify the properties as a comma separated list, e.g. `PROP1=xxx,PROP2=yyy`
+
+|===
+
+Here are the variables for **short-lived** containers, to execute a workflow or pipeline:
 
 |===
 |Environment Variable | Required | Description
 
-|```HOP_LOG_LEVEL```
-| No
-| Specify the log level.Default: ```Basic```.Optional.
-
 |```HOP_FILE_PATH```
 | Yes
-| Path to hop workflow or pipeline
-
-|```HOP_LOG_PATH```
-| No
-| File path to hop log file
-
-|```HOP_CONFIG_DIRECTORY```
-| No
-| Path to the Hop config folder.DISABLED for now.
-
-|```HOP_PROJECT_NAME```
-| Yes
-| Name of the Hop project to use
-
-|```HOP_PROJECT_DIRECTORY```
-| Yes
-| Path to the home of the hop project.Should start with ```/files```.
-
-|```HOP_PROJECT_CONFIG_FILE_NAME```
-| No
-| Name of the project config file including file extension.Defaults to ```project-config.json```.
-
-|```HOP_ENVIRONMENT_NAME```
-| Yes
-| Name of the Hop run environment to use
-
-|```HOP_ENVIRONMENT_CONFIG_FILE_NAME_PATHS```
-| Yes
-| comma separated list of paths to environment config files (including filename and file extension). paths should start with ```/files```.
+| Path to the Hop workflow or pipeline to execute
 
 |```HOP_RUN_CONFIG```
 | Yes
@@ -91,42 +127,60 @@ For **short-lived** containers (execute a workflow or pipeline):
 
 |```HOP_RUN_PARAMETERS```
 | No
-| Parameters that should be passed on to the hop-run command.Specify as comma separated list, e.g. ```PARAM_1=aaa,PARAM_2=bbb```.Optional.
-
-|```HOP_OPTIONS```
-| No
-| Any JRE options you want to set
-
-|```HOP_SHARED_JDBC_DIRECTORY```
-| No
-| Path to the directory where the JDCB drivers are located
-
-|```HOP_CUSTOM_ENTRYPOINT_EXTENSION_SHELL_FILE_PATH```
-| No
-| Path to custom entrypoint extension script file, e.g. to fetch Hop project files from S3 or gitlab.
+| Parameters that should be passed on to the hop-run command.
+You can specify them as a comma separated list, e.g. ```PARAM_1=aaa,PARAM_2=bbb```.Optional.
 
 |===
 
-For **long-lived** containers (Hop Server):
+The variables you can use for the **long-lived** containers (Hop Server):
 
 |===
-|Environment Variable | Description
+|Environment Variable |Default value| Description
 
 |```HOP_SERVER_HOSTNAME```
-| The Hostname the server will have.
-The Hop default is ```localhost```
+| `0.0.0.0` (listen to anything)
+| The IP address the server will listen to.
 
 |```HOP_SERVER_PORT```
+| `8080`
 | The port for hop-server.
-Pick a value like ```8080``` or ```8181```
 
 |```HOP_SERVER_USER```
-| Username for hop-server.
-The Hop default is ```cluster```
+|`cluster`
+| The username to log into the Hop server.
 
 |```HOP_SERVER_PASS```
-| Password for hop-server user.
-The Hop default is ```cluster```
+| `cluster`
+|The password to log into the Hop server
+
+|```HOP_SERVER_METADATA_FOLDER```
+|(optional)
+| You can point to a folder containing metadata JSON files which are then available to the server.
+
+|```HOP_SERVER_MAX_LOG_LINES```
+|`0` (keep all logging in memory)
+|The maximum number of log lines kept in memory by the server.
+
+|```HOP_SERVER_MAX_LOG_TIMEOUT```
+|`0` (never clean up log lines)
+|The time (in minutes) it takes for a log line to be cleaned up in memory.
+
+|```HOP_SERVER_MAX_OBJECT_TIMEOUT```
+|`1440` (a day)
+|The time (in minutes) it takes for a pipeline or workflow execution to be removed from the server status.
+
+|```HOP_SERVER_KEYSTORE```
+| (optional)
+|The path to the Java keystore file you want to use to run the Hop server with SSL enabled. (https://)
+
+|```HOP_SERVER_KEYSTORE_PASSWORD```
+|(optional)
+|The password of the Java keystore file you want to use to run the Hop server with SSL enabled. (https://)
+
+|```HOP_SERVER_KEY_PASSWORD```
+|(optional)
+|The password of the key if you want to use to run the Hop server with SSL enabled.
+If both passwords are the same you can omit setting this variable.
 
 |===
 
@@ -142,7 +196,7 @@ docker pull docker.io/apache/incubator-hop:<tag>
 docker run -it --rm \
   --env HOP_LOG_LEVEL=Basic \
   --env HOP_FILE_PATH='${PROJECT_HOME}/pipelines-and-workflows/main.hwf' \
-  --env HOP_PROJECT_DIRECTORY=/files/project \
+  --env HOP_PROJECT_FOLDER=/files/project \
   --env HOP_PROJECT_NAME=project-a \
   --env HOP_ENVIRONMENT_NAME=project-a-test \
   --env HOP_ENVIRONMENT_CONFIG_FILE_NAME_PATHS=/files/config/project-a-test.json \
@@ -213,7 +267,7 @@ COPY --chown=hop:hop ./resources/clone-git-repo.sh /home/hop/clone-git-repo.sh
 USER hop
 ----
 
-Note that apart from defining the new environment variables (that go in line with the parameters we defined in the ```clone-git-repo.sh``` earlier on ), we also ```COPY``` the ```clone-git-repo.sh``` file to user hop's home directory.
+Note that apart from defining the new environment variables (that go in line with the parameters we defined in the ```clone-git-repo.sh``` earlier on ), we also ```COPY``` the ```clone-git-repo.sh``` file to user hop's home folder.
 
 Next let's build a small script which builds our custom image and then tests it by spinning up a container and running a workflow:
 
@@ -239,7 +293,7 @@ PROJECT_DEPLOYMENT_DIR=/home/hop/apache-hop-minimal-project
 docker run -it --rm \
   --env HOP_LOG_LEVEL=Basic \
   --env HOP_FILE_PATH='${PROJECT_HOME}/main.hwf' \
-  --env HOP_PROJECT_DIRECTORY=${PROJECT_DEPLOYMENT_DIR} \
+  --env HOP_PROJECT_FOLDER=${PROJECT_DEPLOYMENT_DIR} \
   --env HOP_PROJECT_NAME=apache-hop-minimum-project \
   --env HOP_ENVIRONMENT_NAME=dev \
   --env HOP_ENVIRONMENT_CONFIG_FILE_NAME_PATHS=${PROJECT_DEPLOYMENT_DIR}/dev-config.json \

--- a/docs/hop-user-manual/modules/ROOT/pages/hop-server/index.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-server/index.adoc
@@ -218,6 +218,35 @@ In the sample above the environment contains configuration files with variables 
 With the environment the server also knows the project home folder.
 The server configuration file is found in the home folder automatically with the implicit relative path.
 
+=== SSL configuration
+
+To run the Hop server using the `https://` protocol you can add an `sslConfig` section in the `hop-server-config/hop-server` path.
+The 3 main options are:
+
+* `keyStore` : the path to the java keystore file, created with `keytool`
+* `keyStorePassword` : the password to the keystore file
+* `keyPassword` : the key password.
+If this is the same as the keystore password you can omit this option.
+
+Example:
+[source,xml]
+
+----
+<hop-server-config>
+  <hop-server>
+    ...
+
+    <sslConfig>
+      <keyStore>/path/to/keystore.jks</keyStore>
+      <keyStorePassword>password</keyStorePassword>
+      <keyPassword>anotherPassword</keyPassword>
+    </sslConfig>
+
+  </hop-server>
+  ...
+</hop-server-config>
+----
+
 === Stopping Hop Server
 
 In a testing setup where Hop Server was started from a terminal, the process can be terminated through `CTRL-C`.

--- a/integration-tests/transforms/metadata/unit-test/0037-apache-tika UNIT.json
+++ b/integration-tests/transforms/metadata/unit-test/0037-apache-tika UNIT.json
@@ -35,10 +35,6 @@
           "data_set_field": "hiddenFlag"
         },
         {
-          "transform_field": "lastModificationDate",
-          "data_set_field": "lastModificationDate"
-        },
-        {
           "transform_field": "uri",
           "data_set_field": "uri"
         },


### PR DESCRIPTION
HOP-3529 : Add documentation to allow us to configure Hop Server to run with https
HOP-3533 : Ability to set the METADATA_FOLDER in long-lived hop-server
HOP-3548 : Support projects and environments in the long lived docker container
HOP-3549 : Support SSL configurations in long lived container
HOP-3552 : Add docker options for the server logging options 
HOP-3553 : Docker container does not forward exit code
HOP-3554 : The Hop web docker container can't be stopped